### PR TITLE
GREY-45 update packages for Node 5

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -2,6 +2,7 @@
   "name": "indaba-backend",
   "version": "0.2.0",
   "description": "Backend code for Indaba app",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/amida-tech/greyscale.git"
@@ -52,7 +53,7 @@
     "supertest": "^0.13.0"
   },
   "engines": {
-    "node": "~0.12.0"
+    "node": "~5.0.0"
   },
   "scripts": {
     "start": "node --harmony app.js",

--- a/client/Gruntfile.js
+++ b/client/Gruntfile.js
@@ -274,6 +274,7 @@ module.exports = function (grunt) {
                 devDependencies: true,
                 src: '<%= karma.unit.configFile %>',
                 ignorePath: /\.\.\//,
+                exclude: ['bower_components/plotly.js/dist/plotly.min.js'],
                 fileTypes: {
                     js: {
                         block: /(([\s\t]*)\/{2}\s*?bower:\s*?(\S*))(\n|\r|.)*?(\/{2}\s*endbower)/gi,

--- a/client/package.json
+++ b/client/package.json
@@ -2,6 +2,7 @@
   "name": "indaba-client",
   "version": "0.2.0",
   "description": "Client code for Indaba app",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/amida-tech/greyscale.git"
@@ -29,7 +30,7 @@
     "grunt-google-cdn": "^0.4.3",
     "grunt-jsbeautifier": "^0.2.10",
     "grunt-jscs": "^1.8.0",
-    "grunt-karma": "*",
+    "grunt-karma": "^0.12.1",
     "grunt-newer": "^1.1.0",
     "grunt-ng-annotate": "^0.9.2",
     "grunt-ng-constant": "^1.1.0",
@@ -37,14 +38,17 @@
     "grunt-svgmin": "^2.0.0",
     "grunt-usemin": "^3.0.0",
     "grunt-wiredep": "^2.0.0",
+    "jasmine-core": "^2.4.1",
     "jit-grunt": "^0.9.1",
     "jshint-stylish": "^1.0.0",
-    "karma-jasmine": "*",
-    "karma-phantomjs-launcher": "*",
+    "karma": "^0.13.19",
+    "karma-jasmine": "^0.3.6",
+    "karma-phantomjs-launcher": "^0.2.3",
+    "phantomjs": "^2.1.2",
     "time-grunt": "^1.0.0"
   },
   "engines": {
-    "node": "~0.12.0"
+    "node": "~5.0.0"
   },
   "scripts": {
     "start": "grunt serve",

--- a/client/test/karma.conf.js
+++ b/client/test/karma.conf.js
@@ -45,12 +45,21 @@ module.exports = function(config) {
       'bower_components/angular-messages/angular-messages.js',
       'bower_components/angular-inform/dist/angular-inform.js',
       'bower_components/ng-table/dist/ng-table.min.js',
-      'bower_components/plotly.js/dist/plotly.min.js',
       'bower_components/angular-mocks/angular-mocks.js',
       // endbower
+      "app/greyscale.core/scripts/greyscale.core.js",
+      "app/greyscale.core/**/*.js",
+      "app/greyscale.mock/**/*.js",
+      "app/greyscale.rest/**/*.js",
+      "app/greyscale.tables/**/*.js",
+      "app/scripts/app.js",
       "app/scripts/**/*.js",
-//      "test/mock/**/*.js",
-//      "test/spec/**/*.js"
+      "app/vendors/rdash/module.js",
+      "app/vendors/rdash/directives/loading.js",
+      "app/vendors/rdash/directives/widget.js",
+      "app/vendors/rdash/directives/widget-body.js",
+      "app/vendors/rdash/directives/widget-footer.js",
+      "app/vendors/rdash/directives/widget-header.js",
     ],
 
     // list of files / patterns to exclude


### PR DESCRIPTION
- update all deps and install peer deps explicitly for node 5 and npm 3
- specify node 5 in the package.json engines field
- ignore Plotly.js in the test wiredep, as something is breaking in
PhantomJS