### PR TITLE
Hotfix/database clients

### DIFF
--- a/backend/app/db_bootstrap.js
+++ b/backend/app/db_bootstrap.js
@@ -11,6 +11,7 @@ var ClientPG = function () {
 
     client.on('error', function (err) {
         debug(util.format('Connection error: %s', err));
+        client.end();
     });
 
     client.on('drain', client.end.bind(client));

--- a/backend/app/util.js
+++ b/backend/app/util.js
@@ -92,10 +92,6 @@ function arrayString(val) {
     return result;
 }
 
-pg.connect(config.pgConnect, function(err, client, done){
-
-});
-
 exports.Query = function (realm) {
     if (typeof realm === 'undefined') {
         realm = config.pgConnect.adminSchema;
@@ -112,7 +108,7 @@ exports.Query = function (realm) {
 
         pg.connect(config.pgConnect, function (err, client, done) {
             if (err) {
-                return console.error('could not connect to postgres', err);
+                return console.error('Could not fetch client from pool: ', err);
             }
 
             doQuery(queryObject, client, done, options, cb);


### PR DESCRIPTION
This PR checks a client out from a connection pool instead of instantiating a new standalone client for every request. Add property to pgConnect called **idleTimeoutMillis** with your desired client timeout in milliseconds.