### PR TITLE
Scroll comments on admin policy edit view

### DIFF
--- a/client/app/views/controllers/policy-edit.html
+++ b/client/app/views/controllers/policy-edit.html
@@ -10,7 +10,7 @@
                 <policy-block policy-data="model.policy"></policy-block>
             </div>
 
-            <div class="col-sm-5" ng-if="model.policy.taskId">
+            <div class="col-sm-5" ng-if="model.policy.taskId" fixed-on-scroll="{fitHeight: true}">
                 <rd-widget>
                     <rd-widget-header title="{{'SURVEYS.DISCUSSION' | translate}}"></rd-widget-header>
                     <rd-widget-body classes="group-discussion">


### PR DESCRIPTION
#### What's this PR do?
In the Policy Edit view (accessible only by admins), make the Policy Discussion comments box on the right hand side scroll with the window (consistent with the standard Policy view).

#### Related JIRA tickets:
https://jira.amida-tech.com/browse/GREY-627

#### How should this be manually tested?
Go to http://localhost:8081/#/policy/edit/1 as an admin and check the Discussion box remains at the top of the window as you scroll down.

#### Any background context you want to provide?
#### Screenshots (if appropriate):

