### PR TITLE
Remove duplicate text boxes from policy edit form

### DIFF
--- a/client/app/views/directives/fb-policy.html
+++ b/client/app/views/directives/fb-policy.html
@@ -3,7 +3,6 @@
         <uib-accordion-heading>
             <span translate="{{model.label}}"></span><i class="fa pull-right" ng-class="{'fa-caret-up': model.sectionOpen,
                 'fa-caret-down': !model.sectionOpen}"></i></uib-accordion-heading>
-        <text-angular ng-model="model.description" ng-if="!options.readonly" class="line-numbers"></text-angular>
         <div gs-context-menu="contextMenu" qid="{{model.qid}}" class="gs-contextmenu-wrapper dropdown">
             <text-angular id="{{model.qid}}" ng-model="model.description" ng-if="!options.readonly" class="line-numbers"></text-angular>
             <div id="{{model.qid}}" class="line-numbers section-text ta-text" ng-if="options.readonly"


### PR DESCRIPTION
#### What's this PR do?
The policy edit form (for both new and existing policies) had duplicate rich text boxes under each section. This PR removes those.

#### Related JIRA tickets:
https://jira.amida-tech.com/browse/GREY-635
https://jira.amida-tech.com/browse/GREY-636

#### How should this be manually tested?
Go to http://localhost:8081/#/policy/edit/ and http://localhost:8081/#/policy/edit/1 and expand the COVERAGE/DESCRIPTIONS/etc sections. Verify there's only one rich text box under each one. Either write some text in for a new policy, or modify an existing policy and make sure the updates are still saved.

Go to an existing policy as an admin and highlight some text. Verify you get the new comment menu.

#### Any background context you want to provide?
#### Screenshots (if appropriate):

