### PR TITLE
Fix "You has been answered" copy

### DIFF
--- a/client/i18n/en.json
+++ b/client/i18n/en.json
@@ -96,7 +96,7 @@
         "TAG_COMMENT": "Share with...",
         "TITLE": "Make comment",
         "TYPE": "Comment type",
-        "YOU_ANSWERED_ALREADY": "You has been answered.",
+        "YOU_ANSWERED_ALREADY": "You have already responded to this comment and cannot respond again.",
         "YOU_ARE_THE_OWNER": "You are the owner of this comment."
     },
     "COMMON": {


### PR DESCRIPTION
#### What's this PR do?
Replace "You has been answered" with "You have already responded to this comment and cannot respond again"

#### Related JIRA tickets:
https://jira.amida-tech.com/browse/GREY-630

#### How should this be manually tested?
Respond to a comment on a policy, and then try responding to the same comment again. You should see a grammatically correct English response.

#### Any background context you want to provide?
#### Screenshots (if appropriate):

