### PR TITLE
Remove In Draft/Complete policy distinction

### DIFF
--- a/client/app/greyscale.tables/scripts/services/greyscale-project-surveys.js
+++ b/client/app/greyscale.tables/scripts/services/greyscale-project-surveys.js
@@ -33,11 +33,6 @@ angular.module('greyscale.tables')
             dataRequired: false,
             dataFormat: 'text'
         }, {
-            field: 'surveyVersion',
-            title: tns + 'STATUS',
-            show: true,
-            cellTemplate: '<span ng-if="cell===-1" class="text-warning" translate="SURVEYS.IS_DRAFT"></span><span ng-if="(cell!==-1)" class="text-success" translate="SURVEYS.IS_COMPLETE"></span>'
-        }, {
             field: 'created',
             title: tns + 'CREATED',
             show: true,

--- a/client/app/scripts/controllers/policy-edit.js
+++ b/client/app/scripts/controllers/policy-edit.js
@@ -86,12 +86,8 @@ angular.module('greyscaleApp')
         });
 
         //button handlers
-        $scope.save = function () {
-            _save(true);
-        };
-
         $scope.publish = function () {
-            _save(false);
+            _save();
         };
         $scope.cancel = _goBack;
 
@@ -173,17 +169,17 @@ angular.module('greyscaleApp')
             }
         }
 
-        function _save(isDraft) {
+        function _save() {
             var _publish = $q.resolve(false),
                 survey = $scope.model.survey,
                 _deregistator = $scope.$on(greyscaleGlobals.events.survey.builderFormSaved, function () {
                     _deregistator();
-                    if (!isDraft && greyscaleProductSrv.needAcionSecect(survey.product, survey.uoas)) {
+                    if (greyscaleProductSrv.needAcionSecect(survey.product, survey.uoas)) {
                         _publish = greyscaleModalsSrv.dialog(dlgPublish);
                     }
                     _publish
                         .then(function (_action) {
-                            return _saveSurvey(isDraft)
+                            return _saveSurvey()
                                 .then(function () {
                                     if (_action && greyscaleProductSrv.needAcionSecect(survey.product, survey.uoas)) {
                                         return greyscaleProductSrv.doAction(survey.product.id, survey.uoas[0], _action);
@@ -302,15 +298,12 @@ angular.module('greyscaleApp')
                 });
         }
 
-        function _saveSurvey(isDraft) {
+        function _saveSurvey() {
             var _survey,
                 _policy = $scope.model.policy,
                 params = {},
                 _savePromise;
 
-            if (isDraft) {
-                params.draft = true;
-            }
             _survey = angular.extend({}, $scope.model.survey);
             // _survey.projectId = projectId;
             _survey.isPolicy = true;

--- a/client/app/views/controllers/pm-dashboard-product.html
+++ b/client/app/views/controllers/pm-dashboard-product.html
@@ -50,10 +50,6 @@
                                    ng-click="model.surveyEdit()">
                                     <i class="fa" ng-class="{'fa-list': !model.survey.policyId, 'fa-file': model.survey.policyId}"></i>
                                     {{model.survey.title}}
-                                    <small>
-                                        (<span ng-show="model.survey.surveyVersion===-1" translate="SURVEYS.IS_DRAFT">
-                                        </span><span ng-show="model.survey.surveyVersion!==-1" translate="SURVEYS.IS_COMPLETE"></span>)
-                                    </small>
                                 </a>
                             </td>
                             <td>{{model.product.description}}</td>

--- a/client/app/views/controllers/policy-edit.html
+++ b/client/app/views/controllers/policy-edit.html
@@ -24,9 +24,6 @@
         </div>
         <div class="row">
             <div class="form-builder-control text-right">
-                <button class="btn btn-default" ng-click="save()"
-                        ng-disabled="dataForm.$invalid || !dataForm.$dirty || model.lock.locked"
-                        translate="COMMON.SAVE"></button>
                 <button class="btn btn-primary" ng-click="publish()"
                         ng-disabled="publishIsDisabled(dataForm)"
                         translate="POLICY.PUBLISH"></button>

--- a/client/app/views/controllers/project-setup-products.html
+++ b/client/app/views/controllers/project-setup-products.html
@@ -5,9 +5,6 @@
 <script type="text/ng-template" id="project-setup-products-survey.html">
     <span ng-if="option.id">
         <i class="fa" ng-class="{'fa-file':row.policy, 'fa-list': !row.policy}"></i>
-        <span>{{option.title}}
-            <small>(<span ng-show="option.surveyVersion===-1" translate="SURVEYS.IS_DRAFT"></span><span
-                ng-show="!option.surveyVersion!==-1" translate="SURVEYS.IS_COMPLETE"></span>)</small>
-        </span>
+        <span>{{option.title}}</span>
     </span>
 </script>

--- a/client/app/views/directives/policy-block.html
+++ b/client/app/views/directives/policy-block.html
@@ -4,8 +4,7 @@
         <div class="text-right subtext" ng-show="policyData.version !== undefined">
             <a ng-click="printPDF()">Print PDF</a>
             <a class="action-primary" ng-click="listVersions()"><span translate="SURVEYS.VERSION"></span></a>:
-            <span ng-hide="policyData.version < 0">{{policyData.version}}</span>
-            <span ng-show="policyData.version < 0" translate="SURVEYS.VERSION_DRAFT"></span>
+            <span>{{policyData.version}}</span>
         </div>
         <div class="form-group">
             <label for="title" class="col-sm-4 control-label"


### PR DESCRIPTION
#### What's this PR do?
Nurses were getting confused by the In Draft/Complete policy distinction, so this PR marks all policies as complete and removes the status from everywhere in the frontend.

#### Related JIRA tickets:
https://jira.amida-tech.com/browse/GREY-620

#### How should this be manually tested?
Go to http://localhost:8081/#/projects and confirm you see no mention of In Draft/Complete in the Policy column.

Go to http://localhost:8081/#/pm/2 and confirm the same.

Go to http://localhost:8081/#/policy and confirm there's no status column.

Go to http://localhost:8081/#/policy/edit/1 and check the version is listed as -1 not Draft. No future policies will be
marked as In Draft so no policy will show as -1, this just confirms the Draft/Complete check here is gone. Make sure the form only contains a Submit button, not a Save one.

Go to http://localhost:8081/#/policy/edit/ to create a new policy, and confirm the form contains only a Submit button, not a Save one.

#### Any background context you want to provide?
#### Screenshots (if appropriate):

