### PR TITLE
Task/inba 332 logout and multi subjects

### DIFF
--- a/backend/app/controllers/uoas.js
+++ b/backend/app/controllers/uoas.js
@@ -66,23 +66,43 @@ module.exports = {
         });
     },
 
-    insertOne: function (req, res, next) {
+    insert: function (req, res, next) {
         var thunkQuery = req.thunkQuery;
+        var uoas = req.body.name.split(/[ ,]+/);
+        var sqlString = "'"+uoas.toString().replace(/'/g, "''").replace(/,/g, "','")+"'";
+
         co(function* () {
-            req.body.creatorId = req.user.realmUserId; // add from realmUserId instead of user id
-            req.body.ownerId = req.user.realmUserId; // add from realmUserId instead of user id
-            req.body.created = new Date();
-            return yield thunkQuery(UnitOfAnalysis.insert(req.body).returning(UnitOfAnalysis.id));
+            var added = yield thunkQuery(
+                'SELECT name, id FROM "UnitOfAnalysis" WHERE LOWER("UnitOfAnalysis"' +
+                '."name") IN (' + sqlString.toLowerCase() + ') AND "UnitOfAnalysis"' +
+                '."unitOfAnalysisType" = ' + req.body.unitOfAnalysisType
+            );
+
+            console.log(added);
+
+            var insert = _.difference(uoas, added.map((exist) => exist.name));
+            console.log(insert);
+            for (var name in insert) {
+                console.log(name);
+                var id = yield thunkQuery(UnitOfAnalysis.insert({
+                    name,
+                    creatorId: req.user.realmUserId,
+                    ownerId: req.user.realmUserId,
+                    created: new Date(),
+                }).returning(UnitOfAnalysis.id))[0];
+                added.push({name, id})
+            }
+            return added;
         }).then(function (data) {
             bologger.log({
                 req: req,
                 user: req.user,
                 action: 'insert',
                 object: 'UnitOfAnalysis',
-                entity: _.first(data).id,
+                entity: data,
                 info: 'Add new uoa'
             });
-            res.status(201).json(_.first(data));
+            res.status(201).json(data);
         }, function (err) {
             next(err);
         });
@@ -309,17 +329,17 @@ module.exports = {
                             }
                             // ISO
                             if (newUoa.ISO !== '' && (!vl.isAlpha(newUoa.ISO) || !vl.isLength(newUoa.ISO, {
-                                    min: 3,
-                                    max: 3
-                                }))) {
+                                min: 3,
+                                max: 3
+                            }))) {
                                 newUoa.messages.push('`ISO` must not be 3 alpha symbols');
                                 valid = false;
                             }
                             // ISO2
                             if (newUoa.ISO2 !== '' && (!vl.isAlpha(newUoa.ISO2) || !vl.isLength(newUoa.ISO2, {
-                                    min: 2,
-                                    max: 2
-                                }))) {
+                                min: 2,
+                                max: 2
+                            }))) {
                                 newUoa.messages.push('`ISO2` must not be 2 alpha symbols');
                                 valid = false;
                             }

--- a/backend/app/router.js
+++ b/backend/app/router.js
@@ -472,7 +472,7 @@ var UnitOfAnalysis = require('./controllers/uoas');
 
 router.route('/:realm/v0.2/uoas')
     .get(authenticate('jwt').always, UnitOfAnalysis.select)
-    .post(authenticate('jwt').always, jsonParser, checkRight('unitofanalysis_insert_one'), UnitOfAnalysis.insertOne);
+    .post(authenticate('jwt').always, jsonParser, checkRight('unitofanalysis_insert_one'), UnitOfAnalysis.insert);
 
 router.route('/:realm/v0.2/uoas/:id')
     .get(authenticate('jwt').always, UnitOfAnalysis.selectOne)


### PR DESCRIPTION
These changes allow for:
1) Multiple Subjects (also called Units of Analysis or UOAs) to be inserted at once.
2) If a UOA name already exists, it simply returns the existing id for it. If it doesn't exist, we insert a new one and return the created id.
3) Finally, if a productId is provided with the request, we associate the newly created/referenced UOAs with that product.

This has a front end PR that works with it too.