### PR TITLE
Task/inba 340 project user groups table

### DIFF
--- a/backend/app/controllers/projects.js
+++ b/backend/app/controllers/projects.js
@@ -104,11 +104,7 @@ module.exports = {
     selectOne: function (req, res, next) {
         var thunkQuery = req.thunkQuery;
         var aggregateObject = {};
-
-        //Then, when we go to projects to selectOne, we need that array of userGroups the
-        // same way it does now, but just for that project.
-
-
+        
         co(function* () {
             var project = yield thunkQuery(Project.select().from(Project).where(Project.id.equals(req.params.id)), req.query);
 

--- a/backend/app/controllers/projects.js
+++ b/backend/app/controllers/projects.js
@@ -22,6 +22,7 @@ var client = require('../db_bootstrap'),
     UnitOfAnalysis = require('../models/uoas'),
     ProductUOA = require('../models/product_uoa'),
     ProjectUser = require('../models/project_users'),
+    ProjectUserGroup = require('../models/project_user_groups'),
     co = require('co'),
     Query = require('../util').Query,
     vl = require('validator'),
@@ -104,6 +105,10 @@ module.exports = {
         var thunkQuery = req.thunkQuery;
         var aggregateObject = {};
 
+        //Then, when we go to projects to selectOne, we need that array of userGroups the
+        // same way it does now, but just for that project.
+
+
         co(function* () {
             var project = yield thunkQuery(Project.select().from(Project).where(Project.id.equals(req.params.id)), req.query);
 
@@ -166,8 +171,10 @@ module.exports = {
                                 .on(UserGroup.groupId.equals(Group.id))
                                 .leftJoin(User)
                                 .on(User.id.equals(UserGroup.userId))
+                                .leftJoin(ProjectUserGroup)
+                                .on(ProjectUserGroup.groupId.equals(Group.id))
                         )
-                        .where(User.organizationId.equals(project.organizationId))
+                        .where(ProjectUserGroup.projectId.equals(project.id))
                         .group(Group.id)
                 );
 

--- a/backend/app/models/project_user_groups.js
+++ b/backend/app/models/project_user_groups.js
@@ -1,0 +1,8 @@
+var sql = require('sql');
+
+var ProjectUserGroup = sql.define({
+    name: 'ProjectUserGroup',
+    columns: ['projectId', 'groupId']
+});
+
+module.exports = ProjectUserGroup;

--- a/backend/app/models/project_user_groups.js
+++ b/backend/app/models/project_user_groups.js
@@ -1,7 +1,7 @@
 var sql = require('sql');
 
 var ProjectUserGroup = sql.define({
-    name: 'ProjectUserGroup',
+    name: 'ProjectUserGroups',
     columns: ['projectId', 'groupId']
 });
 

--- a/backend/db_setup/schema.indaba.sql
+++ b/backend/db_setup/schema.indaba.sql
@@ -2867,6 +2867,15 @@ CREATE TABLE "ProjectUsers" (
 
 ALTER TABLE "ProjectUsers" OWNER TO indabauser;
 
+
+CREATE TABLE "ProjectUserGroups" (
+    "projectId" integer NOT NULL,
+    "groupId" integer NOT NULL
+);
+
+
+ALTER TABLE "ProjectUserGroups" OWNER TO indabauser;
+
 --
 -- TOC entry 3789 (class 0 OID 0)
 -- Dependencies: 258
@@ -4805,6 +4814,15 @@ CREATE TABLE "ProjectUsers" (
 
 
 ALTER TABLE "ProjectUsers" OWNER TO indabauser;
+
+
+CREATE TABLE "ProjectUserGroups" (
+    "projectId" integer NOT NULL,
+    "groupId" integer NOT NULL
+);
+
+
+ALTER TABLE "ProjectUserGroups" OWNER TO indabauser;
 
 --
 -- TOC entry 394 (class 1259 OID 1601660)
@@ -7950,6 +7968,9 @@ ALTER TABLE ONLY "ProjectUsers"
     ADD CONSTRAINT "ProjectUsers_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Projects"(id);
 
 
+
+ALTER TABLE ONLY "ProjectUserGroups"
+    ADD CONSTRAINT "ProjectUserGroups_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Projects"(id);
 --
 -- TOC entry 3777 (class 0 OID 0)
 -- Dependencies: 9


### PR DESCRIPTION
#What does this PR do
- It created a new `projectUserGroups` table and modified the `projects/selectOne()` function to pull projects from it.

#How can this PR be tested
- Run the user integration test:
`node_modules/.bin/mocha test/user.integration.js --bail -t 10000` and then look in the DB to make sure the `projectUserGroups` table was created. 
- Try selecting a project using `http://localhost:3005/testorg/v0.2/projects/:id` and see that it returns `userGroups: []` as one of the key/val and this should correspond with what's in the `projectUserGroups` table

#Any context needed
- None