### PR TITLE
INBA-403: Return surveyIds with the listAll project list.

### DIFF
--- a/backend/app/controllers/projects.js
+++ b/backend/app/controllers/projects.js
@@ -56,9 +56,11 @@ module.exports = {
                 throw new HttpError(404, 'No projects found');
             } else {
                 for (var i = 0; i < projects.length; i++) {
-                    var productId = _.first(_.map((yield thunkQuery(
-                        Product.select(Product.id).from(Product).where(Product.projectId.equals(projects[i].id))
-                    )), 'id'));
+                    var product = yield thunkQuery(
+                        Product.select(Product.id, Product.surveyId).from(Product).where(Product.projectId.equals(projects[i].id))
+                    );
+
+                    var productId = _.first(_.map(product, 'id'));
 
                     var workflowId = yield thunkQuery(
                         Workflow.select(Workflow.id).from(Workflow).where(Workflow.productId.equals(productId))
@@ -85,6 +87,7 @@ module.exports = {
                         lastUpdated: null,
                         status: projects[i].status,
                         productId,
+                        surveyId: (_.first(_.map(product, 'surveyId')) || null),
                         workflowId: _.first(_.map(workflowId, 'id')),
                         users: [],
                         stages: [],
@@ -104,7 +107,7 @@ module.exports = {
     selectOne: function (req, res, next) {
         var thunkQuery = req.thunkQuery;
         var aggregateObject = {};
-        
+
         co(function* () {
             var project = yield thunkQuery(Project.select().from(Project).where(Project.id.equals(req.params.id)), req.query);
 


### PR DESCRIPTION
When the admin logs into the system, they get a listing of all the projects they've created. Going forward, this object should now return a surveyId with it, be it an integer or a null. This surveyId will be used to get the survey list from the survey microservice. 

To test, deploy and log in as testadmin. Ensure that the projects object returned on the first page (the project list) includes a surveyId with each project. 