### PR TITLE
added check for projects before trying to pull tasks by projectID

### DIFF
--- a/backend/app/controllers/tasks.js
+++ b/backend/app/controllers/tasks.js
@@ -52,12 +52,9 @@ module.exports = {
         var thunkQuery = req.thunkQuery;
         co(function* () {
 
-            //TODO: Check if projects with given id exists first
-
             const projectExist = yield * common.checkRecordExistById(req, 'Projects', 'id', req.params.id)
 
             if (projectExist === true) {
-
                 var tasks = yield thunkQuery(
                     Task
                         .select(

--- a/backend/app/controllers/tasks.js
+++ b/backend/app/controllers/tasks.js
@@ -69,13 +69,13 @@ module.exports = {
                 );
 
                 if (!_.first(tasks)) {
-                    throw new HttpError(403, 'Not found');
+                    throw new HttpError(204, 'No Tasks Found');
                 }
 
                 return yield * common.getFlagsForTask(req, tasks);
 
             } else {
-                throw new HttpError(403, 'No project matching that project ID');
+                throw new HttpError(400, 'No project matching that project ID');
             }
         }).then(function (data) {
             res.json(data);

--- a/backend/app/controllers/tasks.js
+++ b/backend/app/controllers/tasks.js
@@ -54,26 +54,34 @@ module.exports = {
 
             //TODO: Check if projects with given id exists first
 
-            var tasks = yield thunkQuery(
-                Task
-                .select(
-                    Task.star()
-                )
-                .from(
+            const projectExist = yield * common.checkRecordExistById(req, 'Projects', 'id', req.params.id)
+
+            if (projectExist === true) {
+
+                var tasks = yield thunkQuery(
                     Task
-                    .leftJoin(Product)
-                    .on(Product.id.equals(Task.productId))
-                    .leftJoin(Project)
-                    .on(Project.id.equals(Product.projectId))
-                )
-                .where(Project.id.equals(req.params.id))
-            );
+                        .select(
+                            Task.star()
+                        )
+                        .from(
+                            Task
+                                .leftJoin(Product)
+                                .on(Product.id.equals(Task.productId))
+                                .leftJoin(Project)
+                                .on(Project.id.equals(Product.projectId))
+                        )
+                        .where(Project.id.equals(req.params.id))
+                );
 
-            if (!_.first(tasks)) {
-                throw new HttpError(403, 'Not found');
+                if (!_.first(tasks)) {
+                    throw new HttpError(403, 'Not found');
+                }
+
+                return yield * common.getFlagsForTask(req, tasks);
+
+            } else {
+                throw new HttpError(403, 'No project matching that project ID');
             }
-
-            return yield * common.getFlagsForTask(req, tasks);
         }).then(function (data) {
             res.json(data);
         }, function (err) {


### PR DESCRIPTION
#### What's this PR do?
Adds a check in `getTasksByProjectId()` to make sure project with ID exists before trying to pull tasks.

#### Related JIRA tickets:
https://jira.amida-tech.com/browse/INBA-391

#### How should this be manually tested?
- Use postman to hit: `http://localhost:3005/testorg/v0.2/tasks-by-proj-id/2` if this project doesn't exist in the `Projects` table you should get an error letting you know project doesn't exist. 
- Ensure that this works with indaba-client

#### Any background context you want to provide?
Don't forget the auth service - it needs to be running!

#### Screenshots (if appropriate):
