### PR TITLE
Bug/INBA-496 Fix http response when user has no tasks

### DIFF
--- a/backend/app/controllers/tasks.js
+++ b/backend/app/controllers/tasks.js
@@ -123,7 +123,7 @@ module.exports = {
             );
 
             if (!_.first(tasks)) {
-                throw new HttpError(204, 'User has no tasks');
+                res.status(204).end();
             }
 
             return tasks;

--- a/backend/app/controllers/tasks.js
+++ b/backend/app/controllers/tasks.js
@@ -123,7 +123,7 @@ module.exports = {
             );
 
             if (!_.first(tasks)) {
-                throw new HttpError(403, 'Not found');
+                throw new HttpError(204, 'User has no tasks');
             }
 
             return tasks;


### PR DESCRIPTION
This PR changes the http response of `/tasks-by-user-id/:userId` to 204 from 403 when a user has no tasks.

To test, make a request to `/tasks-by-user-id/:userId` for a valid user with no tasks. The response should be HTTP 204 and not HTTP 403