### PR TITLE
Bug/inba 467 fix task assign bug

### DIFF
--- a/backend/app/services/common.js
+++ b/backend/app/services/common.js
@@ -61,7 +61,19 @@ exports.getTaskByStep = getTaskByStep;
 
 var checkDuplicateTask = function* (req, stepId, uoaId, productId) {
     var thunkQuery = req.thunkQuery;
-    var result = yield thunkQuery(Task.select().where(Task.stepId.equals(stepId).and(Task.uoaId.equals(uoaId)).and(Task.productId.equals(productId))));
+    var result = yield thunkQuery(
+        Task.select().where(
+            Task.stepId.equals(
+                stepId
+            ).and(
+                Task.uoaId.equals(uoaId)
+            ).and(
+                Task.productId.equals(productId)
+            ).and(
+                Task.isDeleted.isNull()
+            )
+        )
+    );
     if (_.first(result)) {
         throw new HttpError(403, 'Couldn`t add task with the same uoaId, stepId and productId');
     }


### PR DESCRIPTION
#### What's this PR do?
Allows you to assign a user to a task that was previously deleted

#### Related JIRA tickets:
https://jira.amida-tech.com/browse/INBA-467

#### How should this be manually tested?
- Create a project that has a subject, users, a group, and a stage (with a group assigned)
- Create a task by dragging a user, say, User 1, to a subject/stage (edited)
- Go to the users tab and delete that user that is in order to delete the task assigned to the user. this would be simpler if we had a delete task button. You could also (presumably, i have not tested), delete the task with a REST client
-Now go back to the workflow and drag a different user, say, User 2 to that subject/stage, which will now not have a task assigned to it 
- It shouldn't fail and you shouldn't get a 403 from the backend on the task POST

#### Any background context you want to provide?

#### Screenshots (if appropriate):
