### PR TITLE
Feature INBA-535 - AssignTask Current Step

### DIFF
--- a/backend/app/controllers/projects.js
+++ b/backend/app/controllers/projects.js
@@ -352,7 +352,7 @@ module.exports = {
                     title: result.name,
                     description: req.body.description,
                     projectId: result.id,
-                    status: 0,
+                    status: 1,
                 }).returning(Product.id)
             )).id;
 

--- a/backend/app/controllers/tasks.js
+++ b/backend/app/controllers/tasks.js
@@ -404,7 +404,7 @@ function* updateCurrentStepId(req, insertedTaskId) {
     result = yield thunkQuery(minStepPositionQuery);
 
     if (!_.first(result)) {
-        throw new HttpError(500, 'Could not find the min step position for productId: ' + req.body.productId );
+        throw new HttpError(403, 'Could not find the min step position for productId: ' + req.body.productId );
     }
 
     var addedStep = _.find(result, (step) => step.id === insertedTaskId);

--- a/backend/app/controllers/tasks.js
+++ b/backend/app/controllers/tasks.js
@@ -379,11 +379,7 @@ function* checkTaskData(req) {
 function* updateCurrentStepId(req, insertedTaskId) {
     var thunkQuery = req.thunkQuery;
 
-    // var essenceId = yield * getEssenceId(req, 'Tasks');
     var product = yield * common.getEntity(req, req.body.productId, Product, 'id');
-
-    //TODO: Get survey from survery service if needed
-    // var survey = yield * common.getEntity(req, product.surveyId, Survey, 'id');
     if (product.status !== 2) { // not suspended
         yield thunkQuery(
             ProductUOA.update({
@@ -408,8 +404,7 @@ function* updateCurrentStepId(req, insertedTaskId) {
     result = yield thunkQuery(minStepPositionQuery);
 
     if (!_.first(result)) {
-        debug('Not found min step position for productId `' + req.body.productId + '`');
-        return null;
+        throw new HttpError(500, 'Could not find the min step position for productId: ' + req.body.productId );
     }
 
     var addedStep = _.find(result, (step) => step.id === insertedTaskId);
@@ -433,11 +428,6 @@ function* updateCurrentStepId(req, insertedTaskId) {
         );
     }
         // TODO: Notify user, INBA-529.
-        // var task = yield * common.getTask(req, parseInt(minStepPositions[i].taskId));
-        // notify(req, {
-        //     body: 'Task activated (project started)',
-        //     action: 'Task activated (project started)'
-        // }, task.id, task.id, 'Tasks', 'activateTask');
 
     return {
         productId: req.body.productId,

--- a/backend/app/services/common.js
+++ b/backend/app/services/common.js
@@ -24,7 +24,6 @@ var
     config = require('../../config'),
     request = require('request-promise');
 
-
 var getEntityById = function* (req, id, model, key) {
     var thunkQuery = req.thunkQuery;
     return yield thunkQuery(model.select().from(model).where(model[key].equals(parseInt(id))));


### PR DESCRIPTION
Round 2: Way better implementation.

To Test:
**Explanation: Earlier-in-the-process tasks assigned after later tasks should supersede the latter.**
Create a new project, with users, usergroups, a few subjects and a few stages, preferably 3.
Assign a task to stage 3.
Check the `ProductUOA` table and ensure that a new entry is added, which includes a `currentStepId`.
Assign another task on the same subject as the previous one.
Check the `ProductUOA` table and ensure that a prior entry has changed to an earlier (less) `currentStepId`.

**Explanation: The earlier task should supersede later tasks assigned after.**
On another subject, add a task to stage 1. 
Check the `ProductUOA` table for a new entry.
On the same subject as the prior entry, assign another task to either stage 2 or 3.
Check the `ProductUOA` table and ensure that the entry has not changed.

**Explanation: Later tasks should not overwrite or restart the tasks from stage 1.**
On the final subject, add a task to stage 1 and another to stage 2. 
Check the `ProductUOA` table for a new entry. Manually update it so `currentStepId` is for stage 2 (probably the current id +1).
Assign a task to stage 3
Check the `ProductUOA` table and ensure that the entry has **not** changed.

Note that the project now sets the product to be active on creation. This is necessary as an inactive product does not allow workflow entry/advancement.