### PR TITLE
Feature/inba 530 discussion data

### DIFF
--- a/backend/app/controllers/discussions.js
+++ b/backend/app/controllers/discussions.js
@@ -128,8 +128,8 @@ module.exports = {
             }
 
             var selectQuery = selectFields + selectFrom + selectWhere + selectOrder;
-            var discussionData = _.map(_.groupBy(yield thunkQuery(selectQuery), 'questionId'), function(item, questionId) {
-                return { questionId, item }
+            var discussionData = _.map(_.groupBy(yield thunkQuery(selectQuery), 'questionId'), function(discussion, questionId) {
+                return { questionId, discussion }
             });
             return discussionData;
         }).then(function (data) {

--- a/backend/app/controllers/projects.js
+++ b/backend/app/controllers/projects.js
@@ -352,7 +352,7 @@ module.exports = {
                     title: result.name,
                     description: req.body.description,
                     projectId: result.id,
-                    status: 0,
+                    status: 1,
                 }).returning(Product.id)
             )).id;
 

--- a/backend/app/controllers/tasks.js
+++ b/backend/app/controllers/tasks.js
@@ -404,7 +404,7 @@ function* updateCurrentStepId(req, insertedTaskId) {
     result = yield thunkQuery(minStepPositionQuery);
 
     if (!_.first(result)) {
-        throw new HttpError(500, 'Could not find the min step position for productId: ' + req.body.productId );
+        throw new HttpError(403, 'Could not find the min step position for productId: ' + req.body.productId );
     }
 
     var addedStep = _.find(result, (step) => step.id === insertedTaskId);

--- a/backend/app/controllers/tasks.js
+++ b/backend/app/controllers/tasks.js
@@ -379,11 +379,7 @@ function* checkTaskData(req) {
 function* updateCurrentStepId(req, insertedTaskId) {
     var thunkQuery = req.thunkQuery;
 
-    // var essenceId = yield * getEssenceId(req, 'Tasks');
     var product = yield * common.getEntity(req, req.body.productId, Product, 'id');
-
-    //TODO: Get survey from survery service if needed
-    // var survey = yield * common.getEntity(req, product.surveyId, Survey, 'id');
     if (product.status !== 2) { // not suspended
         yield thunkQuery(
             ProductUOA.update({
@@ -408,8 +404,7 @@ function* updateCurrentStepId(req, insertedTaskId) {
     result = yield thunkQuery(minStepPositionQuery);
 
     if (!_.first(result)) {
-        debug('Not found min step position for productId `' + req.body.productId + '`');
-        return null;
+        throw new HttpError(500, 'Could not find the min step position for productId: ' + req.body.productId );
     }
 
     var addedStep = _.find(result, (step) => step.id === insertedTaskId);
@@ -433,11 +428,6 @@ function* updateCurrentStepId(req, insertedTaskId) {
         );
     }
         // TODO: Notify user, INBA-529.
-        // var task = yield * common.getTask(req, parseInt(minStepPositions[i].taskId));
-        // notify(req, {
-        //     body: 'Task activated (project started)',
-        //     action: 'Task activated (project started)'
-        // }, task.id, task.id, 'Tasks', 'activateTask');
 
     return {
         productId: req.body.productId,

--- a/backend/app/services/common.js
+++ b/backend/app/services/common.js
@@ -24,7 +24,6 @@ var
     config = require('../../config'),
     request = require('request-promise');
 
-
 var getEntityById = function* (req, id, model, key) {
     var thunkQuery = req.thunkQuery;
     return yield thunkQuery(model.select().from(model).where(model[key].equals(parseInt(id))));


### PR DESCRIPTION
Changes to the `select` function of `discussions.js` that return discussion data in a given format.

Builds atop of INBA-535.

**Test:**
On the front end, go into a project, and click on a person's name in the Project Management matrix. On the right, enter a value for "Entry..." and do NOT click "Mark as Resolved." Click send.

Do this for a few different questions within the same task, and send a few on the same question (as to "stack" them). Then do a few more on a different task.

In POSTMAN, do a call to `http://localhost:3005/testorg/v0.2/discussions?taskId=X` where X is the task id (in a task review, it's the very last number of the URL, so for `http://localhost:3000/task-review/4/6`, it would be 6.

Ensure that the returned value is something to the tune of this:
`[
    {
        "questionId": "9",
        "item": [
            {
                "id": 4,
                "taskId": 6,
                "questionId": 9,
                "userId": null,
                "entry": "I'm back!",
                "isReturn": false,
                "created": "2017-12-14T17:22:55.206Z",
                "updated": null,
                "isResolve": false,
                "order": 1,
                "returnTaskId": null,
                "userFromId": 2,
                "stepId": 9,
                "stepFromId": 9,
                "activated": true,
                "uoaId": 2
            },
            {
                "id": 5,
                "taskId": 6,
                "questionId": 9,
                "userId": null,
                "entry": "Stuffs",
                "isReturn": false,
                "created": "2017-12-14T17:23:15.861Z",
                "updated": null,
                "isResolve": false,
                "order": 2,
                "returnTaskId": null,
                "userFromId": 3,
                "stepId": 9,
                "stepFromId": 9,
                "activated": true,
                "uoaId": 2
            }
        ]
    },
    {
        "questionId": "13",
        "item": [
            {
                "id": 6,
                "taskId": 7,
                "questionId": 13,
                "userId": null,
                "entry": "Once more into the fray with Question 3.",
                "isReturn": false,
                "created": "2017-12-14T18:26:25.762Z",
                "updated": null,
                "isResolve": false,
                "order": 1,
                "returnTaskId": null,
                "userFromId": 2,
                "stepId": 10,
                "stepFromId": 10,
                "activated": true,
                "uoaId": 2
            }
        ]
    },
    {
        "questionId": "14",
        "item": [
            {
                "id": 7,
                "taskId": 7,
                "questionId": 14,
                "userId": null,
                "entry": "Stuffing with Question 4.",
                "isReturn": false,
                "created": "2017-12-14T18:26:35.951Z",
                "updated": null,
                "isResolve": false,
                "order": 1,
                "returnTaskId": null,
                "userFromId": 2,
                "stepId": 10,
                "stepFromId": 10,
                "activated": true,
                "uoaId": 2
            }
        ]
    }
]`