### PR TITLE
Feature/inba 579

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -66,6 +66,7 @@
     "grunt-mocha-test": "^0.12.7",
     "jit-grunt": "~0.10.0",
     "jshint-stylish": "^2.1.0",
+    "mock-require": "^2.0.2",
     "sinon": "^2.3.6",
     "supertest": "^0.13.0"
   },

--- a/backend/seed.js
+++ b/backend/seed.js
@@ -19,8 +19,6 @@ const groupCommon = require('./test/util/group-common');
 const History = require('./test/util/History');
 const AuthService = require('./test/util/mock_auth_service');
 
-const dbname = 'indabatestuser';
-
 const authService = new AuthService();
 const superTest = new IndaSuperTest(authService);
 const shared = new SharedIntegration(superTest);
@@ -37,7 +35,7 @@ const organization = config.testEntities.organization;
 const admin = config.testEntities.admin;
 const users = config.testEntities.users;
 
-shared.setupForSeedFn({ dbname })((err, initialized) => {
+shared.setupForSeedFn()((err, initialized) => {
     if (err) {
         console.log('failure');
         console.log(err);

--- a/backend/seed.js
+++ b/backend/seed.js
@@ -1,0 +1,105 @@
+'use strict';
+
+process.env.NODE_ENV = 'test';
+
+const _ = require('lodash');
+const mock = require('mock-require');
+
+mock('request-promise', function mockRequest() {
+    return Promise.resolve({ statusCode: 200 });
+});
+
+const config = require('./config');
+
+const SharedIntegration = require('./test/util/shared-integration');
+const IndaSuperTest = require('./test/util/inda-supertest');
+const organizationCommon = require('./test/util/organization-common');
+const userCommon = require('./test/util/user-common');
+const groupCommon = require('./test/util/group-common');
+const History = require('./test/util/History');
+const AuthService = require('./test/util/mock_auth_service');
+
+const dbname = 'indabatestuser';
+
+const authService = new AuthService();
+const superTest = new IndaSuperTest(authService);
+const shared = new SharedIntegration(superTest);
+const orgTests = new organizationCommon.IntegrationTests(superTest);
+
+const hxGroup = new History();
+const userTests = new userCommon.IntegrationTests(superTest, { hxGroup });
+
+const groupOptions = { hxOrganization: orgTests.hxOrganization, hxGroup };
+const groupTests = new groupCommon.IntegrationTests(superTest, groupOptions);
+
+const superAdmin = config.testEntities.superAdmin;
+const organization = config.testEntities.organization;
+const admin = config.testEntities.admin;
+const users = config.testEntities.users;
+
+shared.setupForSeedFn({ dbname })((err, initialized) => {
+    if (err) {
+        console.log('failure');
+        console.log(err);
+        process.exit(1);
+        return;
+    }
+    if (initialized) {
+        console.log('already initialized');
+        process.exit(1);
+        return;
+    }
+    Promise.resolve()
+        .then(() => authService.addUser(superAdmin))
+        .then(shared.loginFn(superAdmin))
+        .then(orgTests.createOrganizationFn(organization))
+        .then(orgTests.setRealmFn(0))
+        .then(orgTests.getOrganizationFn(0))
+        .then(userTests.inviteUserFn(admin))
+        .then(shared.logoutFn())
+        .then(() => authService.addUser(admin))
+        .then(shared.loginFn(admin))
+        .then(userTests.checkActivitabilityFn(0))
+        .then(userTests.selfActivateFn(0))
+        .then(() => {
+            let px = Promise.resolve();
+            users.forEach((user) => {
+                px = px.then(userTests.inviteUserFn(user));
+            });
+            return px;
+        })
+        .then(shared.logoutFn())
+        .then(() => {
+            let px = Promise.resolve();
+            users.forEach((user, index) => {
+                px = px.then(userTests.selfActivateFn(index + 1));
+                px = px.then(() => authService.addUser(user));
+                px = px.then(shared.loginFn(user));
+                px = px.then(shared.logoutFn());
+            });
+            return px;
+        })
+        .then(shared.loginFn(admin))
+        .then(() => {
+            let px = Promise.resolve();
+            _.range(4).forEach(() => {
+                px = px.then(groupTests.createGroupFn());
+            });
+            return px;
+        })
+        .then(userTests.updateUserGroupsFn(1, [0, 2]))
+        .then(userTests.updateUserGroupsFn(2, [1, 2]))
+        .then(userTests.getUserFn(1))
+        .then(userTests.getUserFn(2))
+        .then(shared.logoutFn())
+        .then(shared.unsetupFn())
+        .then(() => {
+            console.log('success');
+            process.exit(0);
+        })
+        .catch((err) => {
+            console.log('failure');
+            console.log(err);
+            process.exit(1);
+        });
+});

--- a/backend/test/util/pg-util.js
+++ b/backend/test/util/pg-util.js
@@ -38,7 +38,13 @@ const resetDatabase = function resetDatabase(pgConnect, dbName, callback) {
     });
 };
 
+const checkExistanceOfUsers = function (pgConnect, callback) {
+    const query = `SELECT COUNT(*) AS count FROM information_schema.tables WHERE table_schema = 'public' AND table_name = '"Users"'`;
+    runQuery(pgConnect, query, callback);
+};
+
 module.exports = {
     runQuery,
     resetDatabase,
+    checkExistanceOfUsers,
 };

--- a/backend/test/util/pg-util.js
+++ b/backend/test/util/pg-util.js
@@ -39,7 +39,7 @@ const resetDatabase = function resetDatabase(pgConnect, dbName, callback) {
 };
 
 const checkExistanceOfUsers = function (pgConnect, callback) {
-    const query = `SELECT COUNT(*) AS count FROM information_schema.tables WHERE table_schema = 'public' AND table_name = '"Users"'`;
+    const query = `SELECT COUNT(*) AS count FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'Users'`;
     runQuery(pgConnect, query, callback);
 };
 

--- a/backend/test/util/shared-integration.js
+++ b/backend/test/util/shared-integration.js
@@ -83,15 +83,15 @@ class SharedIntegration {
                     return callback(err);
                 }
                 const count = result.rows[0].count;
-                if (count !== 0) {
-                    return callback(null, true);
+                if ((count === 0) || (count === '0')) {
+                    try {
+                        that.initialize(mcl);
+                    } catch (err2) {
+                        return callback(err2);
+                    }
+                    return callback(null, false);
                 }
-                try {
-                    that.initialize(mcl);
-                } catch (err2) {
-                    return callback(err2);
-                }
-                callback(null, false);
+                return callback(null, true);
             });
         };
     }

--- a/backend/test/util/shared-integration.js
+++ b/backend/test/util/shared-integration.js
@@ -18,6 +18,29 @@ class SharedIntegration {
         this.hxUser = hxUser;
     }
 
+    initialize(mcl, dbnamein, dbuserin, hostin) {
+        const dbname = dbnamein || config.pgConnect.database;
+        const dbuser = dbuserin || config.pgConnect.user;
+        const host = hostin || config.pgConnect.host;
+        const schemaPath = path.resolve(__dirname, '../../db_setup/schema.indaba.sql');
+        const dataPath = path.resolve(__dirname, '../../db_setup/data.indaba.sql');
+        const schemaSql = fs.readFileSync(schemaPath);
+        const dataSql = fs.readFileSync(dataPath);
+        childProcess.execSync(`psql -h ${host} -U ${dbuser} ${dbname}`, {
+            input: schemaSql
+        })
+        childProcess.execSync(`psql -h ${host} -U ${dbuser} ${dbname}`, {
+            input: dataSql
+        })
+        const app = appGenerator.generate();
+        const mcClient = app.locals.mcClient;
+        sinon.stub(mcClient, 'set').callsFake((key, value, cb) => mcl.set(key, value, cb));
+        sinon.stub(mcClient, 'get').callsFake((key, cb) => mcl.get(key, cb));
+        sinon.stub(mcClient, 'delete').callsFake((key, cb) => mcl.delete(key, cb));
+        this.indaSuperTest.initialize(app);
+    }
+
+
     setupFn(options) {
         const indaSuperTest = this.indaSuperTest;
         const mcl = new memcacheMock.Client();
@@ -47,6 +70,28 @@ class SharedIntegration {
                 sinon.stub(mcClient, 'delete').callsFake((key, cb) => mcl.delete(key, cb));
                 indaSuperTest.initialize(app);
                 done();
+            });
+        };
+    }
+
+    setupForSeedFn() {
+        const that = this;
+        const mcl = new memcacheMock.Client();
+        return function setUp(callback) {
+            pgUtil.checkExistanceOfUsers(config.pgConnect, (err, result) => {
+                if (err) {
+                    return callback(err);
+                }
+                const count = result.rows[0].count;
+                if (count !== 0) {
+                    return callback(null, true);
+                }
+                try {
+                    that.initialize(mcl);
+                } catch (err2) {
+                    return callback(err2);
+                }
+                callback(null, false);
             });
         };
     }


### PR DESCRIPTION
This creates a 'seed.js' script that replicates what user.integration.js does including running db_setup scripts and user creations.
1) The db needs to be created for user indabauser since db_setup scripts hard codes indabauser. We can change that if that is an issue (createdb -h localhost -U indabauser indaba).
2) This script uses settings in the test branch of config.js.
3) Before the run it checks if there is a 'Users' table in public schema to decide if the db is already initialized.
 