### PR TITLE
Feature/INBA-593 System Generated Messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,9 @@ A list of full environment variable settings is below.  They can be either manua
 - AUTH_SALT: Authorization salt (saltForHash)
 - INDABA_PG_TESTUSER: Dtabase user for test (indabauser)
 - INDABA_USER_TOKEN: Token for user authentication.  Makes it possible to use API without authentication for a particular user.
+- MESSAGE_SERVICE_URL: The root url for the application's message service (http://localhost:4002)
+- SYS_MESSAGE_USER: The email field of the auth service user that is used to send system messages
+- SYS_MESSAGE_PASSWORD: The auth service password for the user that is used to send system messages
 
 ## Deployment with Google Cloud (Kubernetes)
 NOTE: Container Engine SQL support in Google Cloud is bad right now and will probably change.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,3 +4,6 @@ INDABA_PG_PASSWORD=abadni
 INDABA_PG_DB=indabatestuser
 AUTH_SALT=nMsDo)_1fh
 JWT_SECRET=0a6b944d-d2fb-46fc-a85e-0295c986cd9f
+MESSAGE_SERVICE_URL=http://localhost:4002
+SYS_MESSAGE_USER=indaba@example.com
+SYS_MESSSAGE_PASSWORD=password

--- a/backend/app/controllers/system_messages.js
+++ b/backend/app/controllers/system_messages.js
@@ -26,6 +26,12 @@ module.exports = {
                     .then((auth) => {
                         req.app.set(messageService.SYSTEM_MESSAGE_USER_TOKEN_FIELD, auth.token);
                     })
+                    .catch(() => {
+                        const message = 'Failed to send system message. Could not authenticate as system message user'
+                        logger.error(message)
+                        res.status(400, message).end();
+                        throw new Error(message);
+                    })
                     .then(() =>
                         messageService.sendSystemMessage(
                             req.app.get(messageService.SYSTEM_MESSAGE_USER_TOKEN_FIELD),
@@ -37,11 +43,14 @@ module.exports = {
                             logger.debug(resp);
                             res.status(204).end();
                         })
+                        .catch((err) => {
+                            logger.error('Failed to send system message');
+                            logger.error(err);
+                            throw err;
+                        })
                     )
                 }
                 throw err;
-            }).catch(() => {
-                res.status(400).send('Failed to send system message');
             });
         }
     }

--- a/backend/app/controllers/system_messages.js
+++ b/backend/app/controllers/system_messages.js
@@ -1,0 +1,48 @@
+const messageService = require('../services/messages');
+const logger = require('../logger');
+
+module.exports = {
+    send: (req, res) => {
+        if (
+            !req.body.to ||
+            !req.body.message
+        ) {
+            res.status(400).send('System message must have a \'to\' field and a \'message\' field').end();
+        } else {
+            messageService.sendSystemMessage(
+                req.app.get(messageService.SYSTEM_MESSAGE_USER_TOKEN_FIELD),
+                req.body.to,
+                req.body.message,
+                messageService.SYSTEM_MESSAGE_SUBJECT
+            )
+            .then(() => {
+                res.status(204).end();
+            })
+            .catch((err) => {
+                if (err.statusCode === 401) {
+                    logger.debug('Attempt to send a system message was unauthorized');
+                    logger.debug('Reauthenticating and trying again');
+                    return messageService.authAsSystemMessageUser()
+                    .then((auth) => {
+                        req.app.set(messageService.SYSTEM_MESSAGE_USER_TOKEN_FIELD, auth.token);
+                    })
+                    .then(() =>
+                        messageService.sendSystemMessage(
+                            req.app.get(messageService.SYSTEM_MESSAGE_USER_TOKEN_FIELD),
+                            req.body.to,
+                            req.body.message,
+                            messageService.SYSTEM_MESSAGE_SUBJECT
+                        )
+                        .then((resp) => {
+                            logger.debug(resp);
+                            res.status(204).end();
+                        })
+                    )
+                }
+                throw err;
+            }).catch(() => {
+                res.status(400).send('Failed to send system message');
+            });
+        }
+    }
+}

--- a/backend/app/router.js
+++ b/backend/app/router.js
@@ -586,3 +586,10 @@ var logs = require('./controllers/logs');
 
 router.route('/:realm/v0.2/logs')
     .get(authenticate('jwt').always, logs.select);
+
+//----------------------------------------------------------------------------------------------------------------------
+//    System Messages
+//----------------------------------------------------------------------------------------------------------------------
+var SystemMessages = require('./controllers/system_messages');
+router.route('/:realm/v0.2/system_messages')
+    .post(authenticate('jwt').always, jsonParser, SystemMessages.send)

--- a/backend/app/services/messages.js
+++ b/backend/app/services/messages.js
@@ -1,0 +1,64 @@
+const request = require('request-promise');
+const config = require('../../config');
+
+module.exports = {
+    SYSTEM_MESSAGE_USER_TOKEN_FIELD: 'SYSTEM_MESSAGE_USER_TOKEN',
+    SYSTEM_MESSAGE_SUBJECT: 'System Message',
+    createSystemMessageUser: function() {
+        const path = '/user';
+
+        const requestOptions = {
+            url: config.authService + path,
+            method: 'POST',
+            json: {
+                username: config.systemMessageUser,
+                email: config.systemMessageUser,
+                password: config.systemMessagePassword,
+                scopes: [],
+            }
+        };
+
+        return request(requestOptions)
+        .catch((err) => {
+            if (err.statusCode === 400) {
+                return err;
+            }
+            throw err;
+        });
+    },
+
+    authAsSystemMessageUser: function() {
+        const path = '/auth/login';
+
+        const requestOptions = {
+            url: config.authService + path,
+            method: 'POST',
+            json: {
+                username: config.systemMessageUser,
+                password: config.systemMessagePassword,
+            }
+        };
+
+        return request(requestOptions);
+    },
+
+    sendSystemMessage: function(token, recipient, message, subject) {
+        const path = '/api/message/send';
+
+        const requestOptions = {
+            url: config.messageService + path,
+            method: 'POST',
+            headers: {
+                Authorization: `Bearer ${token}`,
+            },
+            json: {
+                to: [recipient],
+                from: config.systemMessageUser,
+                subject,
+                message,
+            }
+        };
+
+        return request(requestOptions);
+    }
+}

--- a/backend/app/services/messages.js
+++ b/backend/app/services/messages.js
@@ -4,29 +4,6 @@ const config = require('../../config');
 module.exports = {
     SYSTEM_MESSAGE_USER_TOKEN_FIELD: 'SYSTEM_MESSAGE_USER_TOKEN',
     SYSTEM_MESSAGE_SUBJECT: 'System Message',
-    createSystemMessageUser: function() {
-        const path = '/user';
-
-        const requestOptions = {
-            url: config.authService + path,
-            method: 'POST',
-            json: {
-                username: config.systemMessageUser,
-                email: config.systemMessageUser,
-                password: config.systemMessagePassword,
-                scopes: [],
-            }
-        };
-
-        return request(requestOptions)
-        .catch((err) => {
-            if (err.statusCode === 400) {
-                return err;
-            }
-            throw err;
-        });
-    },
-
     authAsSystemMessageUser: function() {
         const path = '/auth/login';
 

--- a/backend/config.js
+++ b/backend/config.js
@@ -15,6 +15,9 @@ const base = {
     awsBucket : "your-aws-bucket",
     authService: process.env.AUTH_SERVICE_URL || 'http://localhost:4000/api/v0',
     surveyService: process.env.SURVEY_SERVICE_URL || 'http://localhost:9005/api/v1.0/',
+    messageService: process.env.MESSAGE_SERVICE_URL,
+    systemMessageUser: process.env.SYS_MESSAGE_USER,
+    systemMessagePassword: process.env.SYS_MESSAGE_PASSWORD
 };
 
 var environments = {

--- a/backend/config.js
+++ b/backend/config.js
@@ -106,7 +106,10 @@ var environments = {
                 notificationBody: './views/notifications/welcome.html',
                 emailBody: './views/emails/welcome.html'
             }
-        }
+        },
+        messageService: process.env.MESSAGE_SERVICE_URL || 'http://localhost:4002',
+        systemMessageUser: process.env.SYS_MESSAGE_USER || 'indaba@example.com',
+        systemMessagePassword: process.env.SYS_MESSAGE_PASSWORD || 'password'
     },
 
     test: {


### PR DESCRIPTION
#### What does this PR do?
Supports sending system generated messages in response to the `/system_messages` endpoint

#### Related JIRA tickets:
[INBA-593](https://jira.amida-tech.com/browse/INBA-593)

#### How should this be manually tested?
1. Ensure the message service is running and the three new environment variables are set. They have default values in the development configuration and won't need setting when running locally.
1. Make an authenticated request to `POST /:realm/v0.2/system_messages` with a body json: `{"to": "user1@mail.net", "message": "test message"}`.
1. Check that corresponding rows are created in the message db

### Notes:
I don't sanitize the message body text or the `to` field before sending off to the message service. I'd like someone to check that that's ok. I think it should be since the message service receives the same fields directly from the client.

This implementation of system generated messages requires no changes to the message service, which I like because it limits Indaba-specific influence on the message service design. If we want to support the notion of a system message in the message service, we could add a column to the message table and tell the message service which accounts are considered system accounts.