### PR TITLE
Feature/INBA-626 Remove hash from user activate url

### DIFF
--- a/backend/views/notifications/org_invite.html
+++ b/backend/views/notifications/org_invite.html
@@ -5,5 +5,5 @@
 </p>
 
 <p>
-Please, activate your account by following this <a href="<%= config.domain %>/#/activate/<%= company.realm %>/<%= token %>">link</a>
+Please, activate your account by following this <a href="<%= config.domain %>/activate/<%= company.realm %>/<%= token %>">link</a>
 </p>


### PR DESCRIPTION
Removes the hash from the url sent out in user activation emails. The old client presumably used url fragment navigation but we don't.
See https://github.com/amida-tech/indaba-client/pull/325 for the front end PR