### PR TITLE
Bug/inba 627 correction of email

### DIFF
--- a/backend/app/controllers/users.js
+++ b/backend/app/controllers/users.js
@@ -367,7 +367,7 @@ module.exports = {
             }
 
             // Check if user exists on the auth service first.
-            let userExistOnAuth = yield _getUserOnAuthService(req.body.email, req.headers.authorization);
+            const userExistOnAuth = yield _getUserOnAuthService(req.body.email, req.headers.authorization);
 
             // var isExistsAdmin = yield * common.isExistsUserInRealm(req, config.pgConnect.adminSchema, req.body.email);
             var isExistUser = yield * common.isExistsUserInRealm(req, req.params.realm, req.body.email);
@@ -387,18 +387,18 @@ module.exports = {
 
             // If user is found in greyscale we just check to see if it's been marked as deleted and un-mark it
             if (isExistUser) {
-                if (userExistOnAuth.statusCode !== 200) { // If user does not exist, create him.
-                    userExistOnAuth = yield _createUserOnAuthService(isExistUser.email, isExistUser.password, isExistUser.roleID, req.headers.authorization);
-                }
                 isExistUser.registered = true; // Indicate that the user was previously in the DB
                 const updateObj = {};
-                const authId = typeof userExistOnAuth.body === 'string' ? JSON.parse(userExistOnAuth.body).id : userExistOnAuth.body.id;
+                if (userExistOnAuth.statusCode === 200) {
+                    const authId = typeof userExistOnAuth.body === 'string' ? JSON.parse(userExistOnAuth.body).id : userExistOnAuth.body.id;
+                    if (isExistUser.authId !== authId) { // user needs authId update
+                        updateObj.authId = authId;
+                    }
+                }
                 if (isExistUser.isDeleted !== null) { // user exist and is deleted
                     updateObj.isDeleted = null;
                 }
-                if (isExistUser.authId !== authId) { // user needs authId update
-                    updateObj.authId = authId;
-                }
+
                 if (!_.isEmpty(updateObj)) {
                     yield thunkQuery(User.update(updateObj).where(User.id.equals(isExistUser.id)));
                 }
@@ -410,6 +410,7 @@ module.exports = {
                 return isExistUser;
             }
 
+            const activationToken = crypto.randomBytes(32).toString('hex');
             const salt= crypto.randomBytes(16).toString('hex');
             const pass = crypto.randomBytes(5).toString('hex');
 
@@ -421,19 +422,16 @@ module.exports = {
                 'salt': crypto.randomBytes(16).toString('hex'),
                 'password': User.hashPassword(salt, pass),
                 'isActive': false,
-                'activationToken': crypto.randomBytes(32).toString('hex'),
+                activationToken,
                 'organizationId': org.id,
                 'isAnonymous': req.body.isAnonymous ? true : false,
                 'notifyLevel': req.body.notifyLevel
             };
 
-            if (userExistOnAuth.statusCode !== 200) {
-                userExistOnAuth = yield _createUserOnAuthService(newClient.email, req.body.password, newClient.roleID, req.headers.authorization);
+            if (userExistOnAuth.statusCode === 200) {
+                newClient.authId = typeof userExistOnAuth.body === 'string' ? JSON.parse(userExistOnAuth.body).id : userExistOnAuth.body.id;
             }
-            const authId = typeof userExistOnAuth.body === 'string' ? JSON.parse(userExistOnAuth.body).id : userExistOnAuth.body.id;
 
-                // Using the ID from the auth service, create user on greyscale
-            newClient.authId = authId;
             const userObject = yield thunkQuery(User.insert(newClient).returning(User.id));
             newClient.id = _.first(userObject).id;
 
@@ -449,6 +447,24 @@ module.exports = {
                 entity: _.first(userObject).id,
                 info: 'Add new user (org invite)'
             });
+
+            var essenceId = yield * common.getEssenceId(req, 'Users');
+
+            yield * notifications.createNotification( req, {
+                userFrom: req.user.realmUserId,
+                userTo: _.first(userObject).id,
+                body: 'Invite',
+                essenceId,
+                entityId: _.first(userObject).id,
+                notifyLevel: req.body.notifyLevel,
+                name: req.body.firstName,
+                surname: req.body.lastName,
+                company: org,
+                inviter: req.user,
+                token: activationToken,
+                subject: 'Indaba. Organization membership',
+                config,
+            }, 'orgInvite');
 
             if (req.body.roleID === 2) { // invite admin
                 if (!org.adminUserId) {

--- a/backend/app/controllers/users.js
+++ b/backend/app/controllers/users.js
@@ -266,7 +266,6 @@ module.exports = {
                 throw new HttpError(400, 'Password field is required!');
             }
             const existUser = _.first(isExist);
-            // INBA-607: We need the admin's authorization for the following request, not the req.headers.authorization.
             const userAuthed = yield _createUserOnAuthService(existUser.email, req.body.password, existUser.roleID, req.headers.authorization);
             var data = {
                 activationToken: null,

--- a/backend/config.js
+++ b/backend/config.js
@@ -13,6 +13,7 @@ const base = {
         region: 'us-east-1'
     },
     awsBucket : "your-aws-bucket",
+    indabaDomain: process.env.INDABA_CLIENT_URL || 'http://localhost:3000',
     authService: process.env.AUTH_SERVICE_URL || 'http://localhost:4000/api/v0',
     surveyService: process.env.SURVEY_SERVICE_URL || 'http://localhost:9005/api/v1.0/',
     messageService: process.env.MESSAGE_SERVICE_URL,

--- a/backend/config.js
+++ b/backend/config.js
@@ -13,7 +13,7 @@ const base = {
         region: 'us-east-1'
     },
     awsBucket : "your-aws-bucket",
-    indabaDomain: process.env.INDABA_CLIENT_URL || 'http://localhost:3000',
+    indabaClientDomain: process.env.INDABA_CLIENT_URL || 'http://localhost:3000',
     authService: process.env.AUTH_SERVICE_URL || 'http://localhost:4000/api/v0',
     surveyService: process.env.SURVEY_SERVICE_URL || 'http://localhost:9005/api/v1.0/',
     messageService: process.env.MESSAGE_SERVICE_URL,

--- a/backend/views/emails/activate_task.html
+++ b/backend/views/emails/activate_task.html
@@ -6,7 +6,7 @@
 
 <p>
     Date: <%= date.toLocaleString() %></br>
-    <a href="<%= config.domain %>/#/survey/<%= survey.id %>/task/<%= task.id %>"><%- body %></a>
+    <a href="<%= config.indabaClientDomain %>/#/survey/<%= survey.id %>/task/<%= task.id %>"><%- body %></a>
 </p>
 <p>
     Organisation: <%= organization.name %></br>

--- a/backend/views/emails/assign_task.html
+++ b/backend/views/emails/assign_task.html
@@ -6,7 +6,7 @@
 
 <p>
     Date: <%= date.toLocaleString() %></br>
-    <a href="<%= config.domain %>/#/survey/<%= survey.id %>/task/<%= task.id %>"><%- body %>. You are assigned to task.</a>
+    <a href="<%= config.indabaClientDomain %>/#/survey/<%= survey.id %>/task/<%= task.id %>"><%- body %>. You are assigned to task.</a>
 </p>
 <p>
     Organisation: <%= organization.name %></br>

--- a/backend/views/emails/discussion.html
+++ b/backend/views/emails/discussion.html
@@ -6,7 +6,7 @@
 
 <p>
     Date: <%= date.toLocaleString() %></br>
-    <a href="<%= config.domain %>/#/survey/<%= survey.id %>/task/<%= task.id %>"><%= action %> in the <%= uoa.name %> survey for the <%= product.title %></a></br>
+    <a href="<%= config.indabaClientDomain %>/#/survey/<%= survey.id %>/task/<%= task.id %>"><%= action %> in the <%= uoa.name %> survey for the <%= product.title %></a></br>
     <%= from.firstName %> <%= from.lastName %> posted a discussion comment:</br>
     <%- body %>
 </p>

--- a/backend/views/emails/forgot.html
+++ b/backend/views/emails/forgot.html
@@ -1,7 +1,7 @@
 <p>Hello <%= name %> <%= surname %>!</p>
 
 <p>
-	To restore your password, please click 
-	<a href="<%= config.domain %>/#/reset/<%= realm %>/<%= token %>">here</a> and follow the prompts to enter a new password.
+	To restore your password, please click
+	<a href="<%= config.indabaClientDomain %>/#/reset/<%= realm %>/<%= token %>">here</a> and follow the prompts to enter a new password.
 </p>
 <p>Thank you!</br>-Indaba</p>

--- a/backend/views/emails/invite.html
+++ b/backend/views/emails/invite.html
@@ -3,8 +3,7 @@ Hello <%= name %> <%= surname %>! You have been invited to Indaba as Superadmin.
 </p>
 
 <p>
-To activate your account, please click <a href="<%= config.domain %>/#/activate/<%= config.pgConnect.adminSchema %>/<%= token %>">here</a> and follow the prompts.
+To activate your account, please click <a href="<%= config.indabaClientDomain %>/#/activate/<%= config.pgConnect.adminSchema %>/<%= token %>">here</a> and follow the prompts.
 </p>
 
 <p>Thank you!</br>-Indaba</p>
-

--- a/backend/views/emails/org_invite.html
+++ b/backend/views/emails/org_invite.html
@@ -7,10 +7,7 @@
 </p>
 
 <p>
-Please click <a href="<%= config.indabaDomain %>/activate/<%= company.realm %>/<%= token %>">here</a> to activate your account.
-</p>
-<p>
-However, if you already have an account with Amida, you can simply login <a href="<%= config.indabaDomain %>/login/">here</a>.
+Please click <a href="<%= config.indabaClientDomain %>/activate/<%= company.realm %>/<%= token %>">here</a> to activate your account.
 </p>
 <p>
     Thank you!</br>

--- a/backend/views/emails/org_invite.html
+++ b/backend/views/emails/org_invite.html
@@ -7,7 +7,10 @@
 </p>
 
 <p>
-Please click <a href="<%= config.domain %>/#/activate/<%= company.realm %>/<%= token %>">here</a> to activate your account. 
+Please click <a href="<%= config.indabaDomain %>/activate/<%= company.realm %>/<%= token %>">here</a> to activate your account.
+</p>
+<p>
+However, if you already have an account with Amida, you can simply login <a href="<%= config.indabaDomain %>/login/">here</a>.
 </p>
 <p>
     Thank you!</br>

--- a/backend/views/emails/org_invite_pwd.html
+++ b/backend/views/emails/org_invite_pwd.html
@@ -1,5 +1,5 @@
 <p>
-	Hello <%= name %> <%= surname%>! 
+	Hello <%= name %> <%= surname%>!
 </p>
 
 <p>
@@ -11,7 +11,7 @@
 </p>
 
 <p>
-    Once you login, please click <a href="<%= config.domain %>/#/login">here</a> to change your password.
+    Once you login, please click <a href="<%= config.indabaClientDomain %>/#/login">here</a> to change your password.
 </p>
 
 <p>

--- a/backend/views/emails/resolve_flag.html
+++ b/backend/views/emails/resolve_flag.html
@@ -6,7 +6,7 @@
 
 <p>
     Date: <%= date.toLocaleString() %></br>
-    <a href="<%= config.domain %>/#/survey/<%= survey.id %>/task/<%= task.id %>">Flags were resolved and are ready to be reviewed in the <%= uoa.name %> survey for the <%= product.title %></a>
+    <a href="<%= config.indabaClientDomain %>/#/survey/<%= survey.id %>/task/<%= task.id %>">Flags were resolved and are ready to be reviewed in the <%= uoa.name %> survey for the <%= product.title %></a>
 </p>
 <p>
     Organisation: <%= organization.name %></br>

--- a/backend/views/emails/return_flag.html
+++ b/backend/views/emails/return_flag.html
@@ -6,7 +6,7 @@
 
 <p>
     Date: <%= date.toLocaleString() %></br>
-    <a href="<%= config.domain %>/#/survey/<%= survey.id %>/task/<%= task.id %>">You have <%= flags.count %> flags requiring resolution in the <%= uoa.name %> survey for the <%= product.title %></a>
+    <a href="<%= config.indabaClientDomain %>/#/survey/<%= survey.id %>/task/<%= task.id %>">You have <%= flags.count %> flags requiring resolution in the <%= uoa.name %> survey for the <%= product.title %></a>
 </p>
 <p>
     Organisation: <%= organization.name %></br>

--- a/backend/views/notifications/activate_task.html
+++ b/backend/views/notifications/activate_task.html
@@ -6,7 +6,7 @@
 
 <p>
     Date: <%= date.toLocaleString() %></br>
-    <a href="<%= config.domain %>/#/survey/<%= survey.id %>/task/<%= task.id %>"><%- body %></a>
+    <a href="<%= config.indabaClientDomain %>/#/survey/<%= survey.id %>/task/<%= task.id %>"><%- body %></a>
 </p>
 <p>
     Organisation: <%= organization.name %></br>

--- a/backend/views/notifications/assign_task.html
+++ b/backend/views/notifications/assign_task.html
@@ -6,7 +6,7 @@
 
 <p>
     Date: <%= date.toLocaleString() %></br>
-    <a href="<%= config.domain %>/#/survey/<%= survey.id %>/task/<%= task.id %>"><%- body %>. You are assigned to task.</a>
+    <a href="<%= config.indabaClientDomain %>/#/survey/<%= survey.id %>/task/<%= task.id %>"><%- body %>. You are assigned to task.</a>
 </p>
 <p>
     Organisation: <%= organization.name %></br>

--- a/backend/views/notifications/entry.html
+++ b/backend/views/notifications/entry.html
@@ -6,7 +6,7 @@
 
 <p>
     Date: <%= date.toLocaleString() %></br>
-    <a href="<%= config.domain %>/#/survey/<%= survey.id %>/task/<%= task.id %>"><%= action %> in the <%= uoa.name %> survey for the <%= product.title %></a></br>
+    <a href="<%= config.indabaClientDomain %>/#/survey/<%= survey.id %>/task/<%= task.id %>"><%= action %> in the <%= uoa.name %> survey for the <%= product.title %></a></br>
     <%= from.firstName %> <%= from.lastName %> posted a discussion comment:</br>
     <%- body %>
 </p>

--- a/backend/views/notifications/forgot.html
+++ b/backend/views/notifications/forgot.html
@@ -2,5 +2,5 @@
 
 <p>
 	To restore your password, please follow this
-	<a href="<%= config.domain %>/#/reset/<%= realm %>/<%= token %>">link</a>
+	<a href="<%= config.indabaClientDomain %>/#/reset/<%= realm %>/<%= token %>">link</a>
 </p>

--- a/backend/views/notifications/invite.html
+++ b/backend/views/notifications/invite.html
@@ -3,5 +3,5 @@ Hello <%= name %> <%= surname %>! You have been invited to Indaba as Superadmin.
 </p>
 
 <p>
-Please, activate your account by following this <a href="<%= config.domain %>/#/activate/<%= config.pgConnect.adminSchema %>/<%= token %>">link</a>
+Please, activate your account by following this <a href="<%= config.indabaClientDomain %>/#/activate/<%= config.pgConnect.adminSchema %>/<%= token %>">link</a>
 </p>

--- a/backend/views/notifications/org_invite.html
+++ b/backend/views/notifications/org_invite.html
@@ -5,5 +5,5 @@
 </p>
 
 <p>
-Please, activate your account by following this <a href="<%= config.domain %>/#/activate/<%= company.realm %>/<%= token %>">link</a>
+Please, activate your account by following this <a href="<%= config.indabaClientDomain %>/#/activate/<%= company.realm %>/<%= token %>">link</a>
 </p>

--- a/backend/views/notifications/org_invite_pwd.html
+++ b/backend/views/notifications/org_invite_pwd.html
@@ -1,5 +1,5 @@
 <p>
-	Hello <%= name %> <%= surname%>! 
+	Hello <%= name %> <%= surname%>!
 	<%= inviter.firstName %> <%= inviter.lastName %> has just invited you to Indaba
 	as a member of <%= company.name %> organization.
 </p>
@@ -8,5 +8,5 @@
 </p>
 
 <p>
-Please, <a href="<%= config.domain %>/#/login">login</a> and change your password.
+Please, <a href="<%= config.indabaClientDomain %>/#/login">login</a> and change your password.
 </p>

--- a/backend/views/notifications/resolve_flag.html
+++ b/backend/views/notifications/resolve_flag.html
@@ -6,7 +6,7 @@
 
 <p>
     Date: <%= date.toLocaleString() %></br>
-    <a href="<%= config.domain %>/#/survey/<%= survey.id %>/task/<%= task.id %>">Flags were resolved and are ready to be reviewed in the <%= uoa.name %> survey for the <%= product.title %></a>
+    <a href="<%= config.indabaClientDomain %>/#/survey/<%= survey.id %>/task/<%= task.id %>">Flags were resolved and are ready to be reviewed in the <%= uoa.name %> survey for the <%= product.title %></a>
 </p>
 <p>
     Organisation: <%= organization.name %></br>

--- a/backend/views/notifications/return_flag.html
+++ b/backend/views/notifications/return_flag.html
@@ -6,7 +6,7 @@
 
 <p>
     Date: <%= date.toLocaleString() %></br>
-    <a href="<%= config.domain %>/#/survey/<%= survey.id %>/task/<%= task.id %>">You have <%= flags.count %> flags requiring resolution in the <%= uoa.name %> survey for the <%= product.title %></a>
+    <a href="<%= config.indabaClientDomain %>/#/survey/<%= survey.id %>/task/<%= task.id %>">You have <%= flags.count %> flags requiring resolution in the <%= uoa.name %> survey for the <%= product.title %></a>
 </p>
 <p>
     Organisation: <%= organization.name %></br>


### PR DESCRIPTION
INBA-619 was supposed to send an email to a user to sign in. Unfortunately in my refactoring I accidentally removed the actual function that does that. This reinserts it, and also corrects the link in the email to redirect to the activate page. Unfortunately, it's blocked by 607, as greyscale needs an authentication token to submit a user-creation request. 

Works in tandem with INBA-626.