### PR TITLE
INBA/644 - Fix for the seed.js failing.

### DIFF
--- a/backend/app/controllers/users.js
+++ b/backend/app/controllers/users.js
@@ -454,8 +454,15 @@ module.exports = {
 
             var essenceId = yield * common.getEssenceId(req, 'Users');
 
+            var userFrom;
+            if (req.user.realmUserId) {
+                userFrom = req.user.realmUserId;
+            } else if (newClient.roleID === 2) {
+                userFrom = newClient.id;
+            } // ... else you're going to have a bad time.
+
             yield * notifications.createNotification( req, {
-                userFrom: req.user.realmUserId,
+                userFrom,
                 userTo: _.first(userObject).id,
                 body: 'Invite',
                 essenceId,


### PR DESCRIPTION
You may find that `seed.js` in develop failing since INBA-627. The reason for that is that the notification calls upon a request parameter called `req.user.realmUserId`. This is the organization's admin. 

And, if you are inserting the test admin for the first time, a validation was failing because realmUserId was returning null. This slight change just checks if realmUserId is valid, and if not, it checks if the incoming user is an admin. If so, it can create the notification per normal. Otherwise... bad news bears.