### PR TITLE
Bug/inba 535 assign task

### DIFF
--- a/backend/app/controllers/tasks.js
+++ b/backend/app/controllers/tasks.js
@@ -410,9 +410,9 @@ function* updateCurrentStepId(req, insertedTaskId) {
         )
         .from(ProductUOA.join(WorkflowStep).on(ProductUOA.currentStepId.equals(WorkflowStep.id)))
         .where(ProductUOA.productId.equals(req.body.productId))
-        .and(ProductUOA.UOAid.equals(req.body.uoaId)))) || {};
+        .and(ProductUOA.UOAid.equals(req.body.uoaId))));
 
-    if (_.isEmpty(currentStep) || (currentStep.position + 1 === addedStep.position && currentStep.isComplete)) {
+    if (!currentStep || (currentStep.position + 1 === addedStep.position && currentStep.isComplete)) {
         yield thunkQuery(ProductUOA
             .update({
                 isComplete: false,

--- a/backend/app/controllers/tasks.js
+++ b/backend/app/controllers/tasks.js
@@ -424,6 +424,7 @@ function* updateCurrentStepId(req, insertedTaskId) {
                 .where(Workflow.productId.equals(req.body.productId))
                 .and(WorkflowStep.position.equals(0)))).id;
         } else {
+            // TODO: INBA-561
             updateObj.currentStepId = addedStep.stepId;
         }
 

--- a/backend/app/controllers/tasks.js
+++ b/backend/app/controllers/tasks.js
@@ -412,7 +412,8 @@ function* updateCurrentStepId(req, insertedTaskId) {
         .where(ProductUOA.productId.equals(req.body.productId))
         .and(ProductUOA.UOAid.equals(req.body.uoaId))));
 
-    if (!currentStep || (currentStep.position + 1 === addedStep.position && currentStep.isComplete)) {
+    if (!currentStep || (currentStep.position + 1 === addedStep.position && currentStep.isComplete) ||
+        addedStep.position < currentStep.position) {
         yield thunkQuery(ProductUOA
             .update({
                 isComplete: false,


### PR DESCRIPTION
Relates to: INBA-561/INBA-535/INBA-594

Goal: When assigning tasks, the system should appropriately handle figuring out the current task.

To Test:
Create a full project with no less than three stages. Give it three subjects. Note that the `currentStepId` will correspond to a row in `WorkflowSteps`.

**Scenario 1/Subject 1:**
1. Assign a task to stage 2. Check `ProductUOA` and ensure that the `currentStepId` is now set to the WorkflowSteps of position 0.
2. You may assign additional tasks to the stages after stage 1. The 'currentStepId' should not change.
3. Assign a task to stage 1. Check `ProductUOA` and ensure that the `currentStepId` remains the same.

**Scenario 2/Subject 2:**
1. Assign a task to stage 1. Check `ProductUOA` and ensure that the `currentStepId` is now set.
2. Complete the task by logging in as the user and completing it. Check and ensure that the `currentStepId` is still the same, but `isComplete` is now true.
3. Log out and log back in as the admin. Assign a task to stage 2. Check `ProductUOA` and ensure that the `currentStepId` has updated, and that the `isComplete` is now false again.

**Scenario 3/Subject 3:**
1. Assign a task to stage 1 and another to stage 2. Check `ProductUOA` and ensure that the `currentStepId` is now set to `WorkflowSteps` of position 0.
2. Complete the task by logging out and logging in as the user and completing it.
3. Assign a task to stage 3, leaving stage 2 empty. Check `ProductUOA` and ensure that the `currentStepId` has not updated, and that the `isComplete` is still true.
4. Assign a task to stage 2. Check `ProductUOA` and ensure that the `currentStepId` has updated, and that the `isComplete` is now false again.

Logic:
- When there is no track (`ProductUOA` table), one is created. The initial `currentStepId` will be the WorkflowStep with position 0. It will do this no matter where the task is assigned, insuring that they must advance down the flow. 
- If a task is assigned and completed without another task behind it, `isComplete` is marked as true. If another task is then assigned _sequentially_ after it, the `isComplete` becomes false and the new sequential task becomes the `currentStepId`.

Note: In theory, this may cause deleting stages to need some work. However, that was probably the case anyway. 