### PR TITLE
Bug/INBA-633 Task complete flag

### DIFF
--- a/backend/app/controllers/tasks.js
+++ b/backend/app/controllers/tasks.js
@@ -163,7 +163,8 @@ module.exports = {
                 'AND "Tasks"."isDeleted" is NULL ' +
                 ') '
             );
-            return yield * common.getFlagsForTask(req, tasks);
+            tasks = yield * common.getFlagsForTask(req, tasks);
+            return tasks = yield * common.getCompletenessForTask(req, tasks);
         }).then(function (data) {
             res.json(data);
         }, function (err) {

--- a/backend/app/services/common.js
+++ b/backend/app/services/common.js
@@ -4,6 +4,7 @@ var
     Product = require('../models/products'),
     ProductUOA = require('../models/product_uoa'),
     Essence = require('../models/essences'),
+    Workflow = require('../models/workflows'),
     WorkflowStep = require('../models/workflow_steps'),
     WorkflowStepGroup = require('../models/workflow_step_groups'),
     Group = require('../models/groups'),
@@ -413,6 +414,58 @@ var getFlagsForTask = function* (req, tasks) {
 
 exports.getFlagsForTask = getFlagsForTask;
 
+var getCompletenessForTask = function* (req, tasks) {
+    var thunkQuery = req.thunkQuery;
+    for (var i = 0; i < tasks.length; i++) {
+        tasks[i].complete = false;
+
+        // Task is complete if the corresponding ProductUOA is at the task's step and is marked isComplete
+        var completeAndCurrent = yield thunkQuery(
+            ProductUOA
+            .select()
+            .where(
+                ProductUOA.UOAid.equals(tasks[i].uoaId)
+                .and(ProductUOA.productId.equals(tasks[i].productId))
+                .and(ProductUOA.currentStepId.equals(tasks[i].stepId))
+                .and(ProductUOA.isComplete.equals(true))
+            )
+        );
+        if (completeAndCurrent.length > 0) {
+            tasks[i].complete = true;
+        } else {
+            // Task is complete if the corresponding ProductUOA is at a step with a higher position than the task's
+            var taskPosition = yield thunkQuery(
+                WorkflowStep.select(WorkflowStep.position)
+                .where(
+                    WorkflowStep.id.equals(tasks[i].stepId)
+                )
+            );
+            var currentPosition = yield thunkQuery(
+                WorkflowStep.select(WorkflowStep.position)
+                .from(WorkflowStep
+                    .leftJoin(Workflow)
+                    .on(WorkflowStep.workflowId.equals(Workflow.id))
+                    .leftJoin(ProductUOA)
+                    .on(ProductUOA.productId.equals(Workflow.productId))
+                )
+                .where(
+                    Workflow.productId.equals(tasks[i].productId)
+                    .and(WorkflowStep.id.equals(ProductUOA.currentStepId))
+                    .and(ProductUOA.UOAid.equals(tasks[i].uoaId))
+                )
+            );
+
+            if (currentPosition.length === 1 && taskPosition.length === 1 &&
+                currentPosition[0].position > taskPosition[0].position) {
+                tasks[i].complete = true;
+            }
+        }
+    }
+    return tasks;
+}
+
+exports.getCompletenessForTask = getCompletenessForTask;
+
 var insertProjectUser = function* (req, userId, projectId) {
     var thunkQuery = req.thunkQuery;
     var data = yield thunkQuery(ProjectUser.select().where({ projectId, userId }));
@@ -535,4 +588,3 @@ var getCompletedTaskByStepId = function* (req, workflowStepId) {
 };
 
 exports.getCompletedTaskByStepId = getCompletedTaskByStepId;
-


### PR DESCRIPTION
[INBA-633](https://jira.amida-tech.com/browse/INBA-633)

This PR adds a `complete` property to tasks returned from the `/tasks-self` endpoint which is calculated from the ProductUOA and WorkflowSteps tables.

Please carefully check the sql queries used in the calculations. The intended logic is:
A task is complete if:
1. The corresponding ProductUOA's `currentStepId` is equal to the Task's `stepId` and the ProductUOA's `isComplete` is true
OR
2. The `position` column of the WorkflowStep corresponding to the ProductUOA's `currentStepId` is higher than the `position` column of the WorkflowStep corresponding to the Task's `stepId`