### PR TITLE
Bug/INBA-635 Add active field to self tasks

### DIFF
--- a/backend/app/controllers/tasks.js
+++ b/backend/app/controllers/tasks.js
@@ -165,7 +165,8 @@ module.exports = {
                 ') '
             );
             tasks = yield * common.getFlagsForTask(req, tasks);
-            return tasks = yield * common.getCompletenessForTask(req, tasks);
+            tasks = yield * common.getCompletenessForTask(req, tasks);
+            return tasks = yield * common.getActiveForTask(req, tasks);
         }).then(function (data) {
             res.json(data);
         }, function (err) {

--- a/backend/app/services/common.js
+++ b/backend/app/services/common.js
@@ -466,6 +466,28 @@ var getCompletenessForTask = function* (req, tasks) {
 
 exports.getCompletenessForTask = getCompletenessForTask;
 
+var getActiveForTask = function* (req, tasks) {
+    var thunkQuery = req.thunkQuery;
+    for (var i = 0; i < tasks.length; i++) {
+        // Task is active if the corresponding ProductUOA is at the task's step and is not marked isComplete
+        var current = yield thunkQuery(
+            ProductUOA
+            .select()
+            .where(
+                ProductUOA.UOAid.equals(tasks[i].uoaId)
+                .and(ProductUOA.productId.equals(tasks[i].productId))
+                .and(ProductUOA.currentStepId.equals(tasks[i].stepId))
+                .and(ProductUOA.isComplete.equals(false))
+            )
+        );
+
+        tasks[i].active = current.length > 0;
+    }
+    return tasks;
+}
+
+exports.getActiveForTask = getActiveForTask;
+
 var insertProjectUser = function* (req, userId, projectId) {
     var thunkQuery = req.thunkQuery;
     var data = yield thunkQuery(ProjectUser.select().where({ projectId, userId }));


### PR DESCRIPTION
This PR adds a function to calculate and add an `active` field to tasks, and adds the field to task objects returned by the self tasks endpoint. This is used by the front end to limit the tasks in the user dashboard to those that are complete or active.

See https://github.com/amida-tech/indaba-client/pull/354