### PR TITLE
removed sys user so we don't have it showing up on greyscale

### DIFF
--- a/backend/config.js
+++ b/backend/config.js
@@ -204,14 +204,6 @@ var environments = {
                     roleID: 3,
                     password: 'testuser12345',
                     authId: 3,
-                },
-                //Added this user to be created on the auth service
-                {
-                    firstName: 'SYSMessageUser',
-                    lastName: 'SYSMessageUser',
-                    email: 'indaba@example.com',
-                    roleID: 3,
-                    password: 'password',
                 }
             ],
             organization : {


### PR DESCRIPTION
Removed indaba@example.com from greyscale

In order for you to run `user.integration` you'll need to have `indaba@example.com` and `su@mail.net` created on the auth service.