### PR TITLE
INBA-761 - Need to return existing user too.

### DIFF
--- a/backend/app/controllers/users.js
+++ b/backend/app/controllers/users.js
@@ -392,8 +392,6 @@ module.exports = {
 
             // If a user is found in greyscale we just check to see if it's been marked as deleted and un-mark it
             if (isExistUser) {
-                console.log('*******************');
-                console.log(isExistUser);
                 isExistUser.registered = true; // Indicate that the user was previously in the DB
                 const updateObj = {};
                 if (userExistOnAuth.statusCode === 200) {

--- a/backend/app/controllers/users.js
+++ b/backend/app/controllers/users.js
@@ -392,6 +392,8 @@ module.exports = {
 
             // If a user is found in greyscale we just check to see if it's been marked as deleted and un-mark it
             if (isExistUser) {
+                console.log('*******************');
+                console.log(isExistUser);
                 isExistUser.registered = true; // Indicate that the user was previously in the DB
                 const updateObj = {};
                 if (userExistOnAuth.statusCode === 200) {
@@ -412,6 +414,7 @@ module.exports = {
                 if (req.body.projectId && isExistUser.isActive) {
                     yield * common.insertProjectUser(req, isExistUser.id, req.body.projectId);
                 }
+                return isExistUser;
             }
 
             // if the user didn't exist, or exists but is not active, send an invitation


### PR DESCRIPTION
Prior PRs slightly broke the user invites. When a user was already in a system, it was supposed to just assign them to the project and return the existing user for insertion into the User Lists, displaying a toast pop up like ("The user is already in the system, but we've added them to the project for you..." 

To test, create a project and invite a user who is already in the system but not yet assigned to the project. Ensure that the user appears in the list and you get the toast. Then, invite a brand new user into the project. Ensure that you get the "User invited" toast and the user appears. 