### PR TITLE
task/INBA-766-PO-export-flags - Added functionality to download flags and other project data as a zip file

### DIFF
--- a/backend/app/controllers/products.js
+++ b/backend/app/controllers/products.js
@@ -546,8 +546,6 @@ module.exports = {
 
             var data = zip.generate({ base64:false, compression: 'DEFLATE' });
 
-            data = data.toString(2);
-
             return data
 
         }).then(function (data) {

--- a/backend/app/controllers/products.js
+++ b/backend/app/controllers/products.js
@@ -520,8 +520,12 @@ module.exports = {
 
                 // Get flags for each question and create a new csv
                 const flags = yield thunkQuery(
-                    Discussion.select().from(Discussion)
-                        .where(Discussion.questionId.equals(parseInt(exportData.body[i].questionId)))
+                    Discussion.select(Discussion.star(), Task.assessmentId).from(
+                        Discussion.leftJoin(Task)
+                        .on(Discussion.taskId.equals(Task.id))
+                    )
+                    .where(Discussion.questionId.equals(parseInt(exportData.body[i].questionId))
+                    .and(Task.assessmentId.equals(exportData.body[i].assessmentId)))
                 );
                 for (var flag = 0; flag < flags.length; flag++) {
                     const formattedFlagCsv = {};

--- a/backend/app/controllers/products.js
+++ b/backend/app/controllers/products.js
@@ -32,8 +32,6 @@ var
     pgEscape = require('pg-escape'),
     config = require('../../config'),
     surveyService = require('../services/survey'),
-    fs = require('fs'),
-    path = require('path'),
     zip = new require('node-zip')(),
     request = require('request');
 
@@ -480,7 +478,6 @@ module.exports = {
             const formattedExportData = [];
             const flagsExportData = [];
 
-
             const fields = [ // List of CSV columns
                 'subject', 'user', 'surveyName', 'stage', 'question', 'questionType', 'response', 'choiceText',
                 'publicationLink', 'publicationTitle', 'publicationAuthor', 'publicationDate', 'commenter',
@@ -543,6 +540,7 @@ module.exports = {
             const csv = json2csv({ data: formattedExportData, fields: fields });
             const flagsCsv = json2csv({ data: flagsExportData, fields: flagFields});
 
+            // Zip both files before sending to client
             zip.file('projectData.csv', csv);
             zip.file('flagsData.csv', flagsCsv);
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -31,6 +31,7 @@
     "multer": "0.1.3",
     "mz": "1.1.0",
     "node-uuid": "1.4.1",
+    "node-zip": "^1.1.1",
     "nodemailer": "^2.7.2",
     "nodemailer-smtp-transport": "2.x",
     "passport": "0.2.1",


### PR DESCRIPTION
What does this PR do:
 - Adds feature to create separate csv for flags 
 - Zips both csv's up and sends to the client for download

To Test:
 - Create a project, survey, assign task, complete task etc.
 - Download the csv from the client
 - You should get a zip file containing two csv's- one for the project data and one for just flags

Make sure you have `feature/inba-765-jf-export` running on the front end if it hasn't been merged as well as `feature/ser-29-get-answers-by-question-number` on the surveyService