### PR TITLE
INBA-816/added check for users with only live tasks 

### DIFF
--- a/backend/app/controllers/projects.js
+++ b/backend/app/controllers/projects.js
@@ -418,7 +418,7 @@ module.exports = {
                 );
 
                 if (result) { // If the status was changed
-                    if (parseInt(updateObj.status) ===1 || parseInt(updateObj.status) === 0) { // status was changed
+                    if (parseInt(updateObj.status) === 1 || parseInt(updateObj.status) === 0) { // status was changed
                         const product = yield thunkQuery(
                             Product.select().from(Product).where(Product.projectId.equals(req.params.id))
                         );
@@ -437,9 +437,14 @@ module.exports = {
                                         .and(Task.uoaId.equals(productUoas[p].UOAid))
                                 )
                             );
-                            usersWithLiveTasks.push(_.first(tasks)); // Push user ids to list
-                        }
+                            // Append only users with live tasks
+                            const taskStartDate = _.first(tasks).startDate;
+                            const currentDate = new Date();
 
+                            if (currentDate > taskStartDate) {
+                                usersWithLiveTasks.push(_.first(tasks)); //Push user ids to list
+                            }
+                        }
                         // Email users based on active or in-active project
                         let emailBodyAndAction = {};
                         if (parseInt(updateObj.status) === 1 ) { // project made Active


### PR DESCRIPTION
If this PR fixes a bug, you _must_ add test cases representative of the bug.

Please refer to [Tettra](https://app.tettra.co/teams/amida/pages/amida-pull-request-and-code-review-guide) for PR review guidelines.

#### What does this PR do?
Notifies only users with "live tasks" (these are tasks with start dates not in the future).

#### Related JIRA tickets:
https://jira.amida-tech.com/browse/INBA-816

#### How should this be manually tested?
- Assign a task to a stage with a future start date
- Make the project active
- That user shouldn't get a notification.

#### Background/Context

#### Screenshots (if appropriate):
