### PR TITLE
INBA-865 / Allow user to be assigned whether or not they're active

### DIFF
--- a/backend/app/controllers/users.js
+++ b/backend/app/controllers/users.js
@@ -357,12 +357,14 @@ module.exports = {
     },
 
     selfOrganizationInvite: function (req, res, next) {
+        console.log('@@@@@@@@@@@@@@@@@@@selfOrgInvite');
 
         if (req.params.realm === config.pgConnect.adminSchema) {
             throw new HttpError(400, 'Incorrect realm');
         }
 
         co(function* () {
+            console.log(req.body);
             if (req.body.roleID === 1) {
                 throw new HttpError(400, 'You cannot invite super admins');
             }
@@ -413,7 +415,7 @@ module.exports = {
                 }
 
                 // If user is in greyscale and not deleted add to project if needed
-                if (req.body.projectId && isExistUser.isActive) {
+                if (req.body.projectId) {
                     yield * common.insertProjectUser(req, isExistUser.id, req.body.projectId);
                 }
                 return isExistUser;


### PR DESCRIPTION
#### What does this PR do?
Allows a user to be assigned to a project, regardless of if they are active or not.

#### Related JIRA tickets:
INBA-865.

#### How should this be manually tested?
Try assigning a user to a project when the user is inactive. You should now be able to. 

#### Background/Context
This was presenting errors on the front end where the admin was being led to believe the user was assigned when they weren't. 

#### Screenshots (if appropriate):
