### PR TITLE
Bug/inba 888 & 887 / jf cache mem outside

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Indaba puts your stakeholder and expert network at your fingertips. It converts 
 - Node.js (v5 - we recommend using [node version manager](https://github.com/creationix/nvm))
 - PostgreSQL
 - pgAdmin (optional)
-- memcached
 - nginx (for server deployment)
 - Docker
 
@@ -200,7 +199,7 @@ See the [paper](https://paper.dropbox.com/doc/Amida-Microservices-Kubernetes-Dep
 ### A Few Things to Note
 - The  `.pgpass` file is needed by the `Dockerfile` to run the `seed.js` script upon startup. This is only necessary when seeding password protected databases. You will need to ensure that the file is configured with the correct database parameters in this format `hostname:port:database:username:password`.
 
-- If using AWS' Elasticache and RDS to deploy memcached and postgres respectively, make sure the instance is configured with the appropriate security groups to allow traffic from the cluster's instance. The paper doc referenced above describes how this can be done.
+- If using AWS' Elasticache and RDS to deploy postgres, make sure the instance is configured with the appropriate security groups to allow traffic from the cluster's instance. The paper doc referenced above describes how this can be done.
 
 ## Deployment with Google Cloud (Kubernetes)
 NOTE: Container Engine SQL support in Google Cloud is bad right now and will probably change.
@@ -230,7 +229,7 @@ kompose convert
 # you may need to authenticate first
 gcloud auth application-default login
 # create the pods
-kubectl create -f indaba-frontend-service.yaml,memcached-service.yaml,indaba-backend-service.yaml,indaba-frontend-deployment.yaml,memcached-deployment.yaml,indaba-backend-deployment.yaml
+kubectl create -f indaba-frontend-service.yaml,indaba-backend-service.yaml,indaba-frontend-deployment.yaml,indaba-backend-deployment.yaml
 # to verify in the kubernetes dashboard:
 kubectl proxy
 # then navigate to localhost:8001/ui

--- a/backend/README.md
+++ b/backend/README.md
@@ -30,10 +30,10 @@ node --harmony app.js (since 4.0.0 version --harmony is not necessary)
 
 # Set up environment variables
 ```
-# Copy the environment variables 
+# Copy the environment variables
 cp .env.example .env
 
-# Insert values for the following 
+# Insert values for the following
 GMAIL_PASS=enter-password
 MESSAGE_SERVICE_URL=http://localhost:4002
 SYS_MESSAGE_USER=indaba@example.com
@@ -64,18 +64,15 @@ Indaba uses [`debug`](https://github.com/visionmedia/debug) package. To turn deb
 - `cd backend/db_setup`
 - `docker build --tag indaba_pg_backend .`
 -  now to run an instance `docker run -e POSTGRES_USER=indabauser -e POSTGRES_PASSWORD=<password/> -e POSTGRES_DB=indaba --name indaba_pg indaba_pg_backend`
-2. Now create a memcached instance `docker run --name indaba_memcached memcached`
-3. Create the backend image
+2. Create the backend image
 - `cd ../` (should now be in the backend directory)
-- `docker build --tag inadba_backend`
-- `docker run --link indaba_pg:indaba_pg --link indaba_memcached:indaba_memcached -e INDABA_PG_PASSWORD=<pg password/> -e INDABA_PG_HOSTNAME=indaba_pg -e AUTH_SALT=<salt/> -e JWT_SECRET=<JWT_SECRET/> -e MEMCACHED_HOST=indaba_memcached -p 3005:3005 --name indaba_be indaba_backend`
+- `docker build --tag indaba_backend`
+- `docker run --link indaba_pg:indaba_pg -e INDABA_PG_PASSWORD=<pg password/> -e INDABA_PG_HOSTNAME=indaba_pg -e AUTH_SALT=<salt/> -e JWT_SECRET=<JWT_SECRET/> -p 3005:3005 --name indaba_be indaba_backend`
 - i. `--link indaba_pg:indaba_pg` links to the pg instance we created and calls in indaba_pg
-- ii. `--link indaba_memcached:indaba_memcached` links the memcached instance we created and calls it indaba_memcached
-- iii. `-e INDABA_PG_PASSWORD=<pg password/>` sets the environment variable to the password we specified when creating the PG instance
-- iv. `-e INDABA_PG_HOSTNAME=indaba_pg` sets the environment variable for the app to specify the name of the pg instance to the name we linked it as in i
-- v. `-e AUTH_SALT=<salt/>` sets the salt
-- vi. `-e JWT_SECRET=<JWT_SECRET/>` sets the JWT secret
-- vii. `-e MEMCACHED_HOST=indaba_memcached` sets the environment variable for the app to specify the name of the memcached instance to the name we linked it as in ii
+- ii. `-e INDABA_PG_PASSWORD=<pg password/>` sets the environment variable to the password we specified when creating the PG instance
+- iii. `-e INDABA_PG_HOSTNAME=indaba_pg` sets the environment variable for the app to specify the name of the pg instance to the name we linked it as in i
+- vi. `-e AUTH_SALT=<salt/>` sets the salt
+- v. `-e JWT_SECRET=<JWT_SECRET/>` sets the JWT secret
 
 # Code Analysis
 From `/backend`

--- a/backend/app/app-generator.js
+++ b/backend/app/app-generator.js
@@ -6,12 +6,10 @@ const thunkify = require('thunkify');
 const multer = require('multer');
 const passport = require('passport');
 const pg = require('pg');
-const memcache = require('memcache');
 
 const config = require('../config');
 const logger = require('./logger');
 const router = require('./router');
-const mc = require('./mc_helper');
 const HttpError = require('./error').HttpError;
 const Query = require('./util').Query;
 
@@ -45,28 +43,9 @@ const initExpress = function (app) {
             require('./socket/socket-controller.server').init(server);
         });
     };
-
-    // MEMCHACHE
-    var mcClient = new memcache.Client(
-        config.mc.port,
-        config.mc.host
-    );
-
-    mcClient.on('connect', function () {
-        logger.debug('mc connected');
-        startServer();
-    });
-
-    mcClient.on('error', function (e) {
-        logger.error('MEMCACHE ERROR');
-        logger.debug(e);
-    });
-
-    app.locals.mcClient = mcClient; // eslint-disable-line no-param-reassign
-
+    startServer();
     app.use(function (req, res, next) {
         logger.debug('Request URL:', req.url);
-        req.mcClient = mcClient;
         next();
     });
 
@@ -76,36 +55,17 @@ const initExpress = function (app) {
 
         var schemas;
         co(function* () {
-            if (process.env.BOOTSTRAP_MEMCACHED !== 'DISABLE') {
-                try {
-                    schemas = yield mc.get(req.mcClient, 'schemas');
-                } catch (e) {
-                    throw new HttpError(500, e);
-                }
-            }
-
-            if (schemas) {
-                req.schemas = schemas.split(',');
-            } else {
-                schemas = yield thunkQuery(
-                    'SELECT pg_catalog.pg_namespace.nspname ' +
-                    'FROM pg_catalog.pg_namespace ' +
-                    'INNER JOIN pg_catalog.pg_user ' +
-                    'ON (pg_catalog.pg_namespace.nspowner = pg_catalog.pg_user.usesysid) ' +
-                    'AND (pg_catalog.pg_user.usename = \'' + cpg.user + '\')'
-                );
-                req.schemas = [];
-                for (var i in schemas) {
-                    if ([cpg.sceletonSchema, cpg.adminSchema].indexOf(schemas[i].nspname) === -1) {
-                        req.schemas.push(schemas[i].nspname);
-                    }
-                }
-                if (process.env.BOOTSTRAP_MEMCACHED !== 'DISABLE') {
-                    try {
-                        schemas = yield mc.set(req.mcClient, 'schemas', req.schemas, 60);
-                    } catch (e) {
-                        throw new HttpError(500, e);
-                    }
+            schemas = yield thunkQuery(
+                'SELECT pg_catalog.pg_namespace.nspname ' +
+                'FROM pg_catalog.pg_namespace ' +
+                'INNER JOIN pg_catalog.pg_user ' +
+                'ON (pg_catalog.pg_namespace.nspowner = pg_catalog.pg_user.usesysid) ' +
+                'AND (pg_catalog.pg_user.usename = \'' + cpg.user + '\')'
+            );
+            req.schemas = [];
+            for (var i in schemas) {
+                if ([cpg.sceletonSchema, cpg.adminSchema].indexOf(schemas[i].nspname) === -1) {
+                    req.schemas.push(schemas[i].nspname);
                 }
             }
 

--- a/backend/app/bootstrap.js
+++ b/backend/app/bootstrap.js
@@ -8,10 +8,6 @@ const appGenerator = require('./app-generator');
 
 const app = appGenerator.generate();
 
-app.on('start', function () {
-    app.locals.mcClient.connect();
-});
-
 app.emit('start');
 
 module.exports = app;

--- a/backend/app/controllers/organizations.js
+++ b/backend/app/controllers/organizations.js
@@ -20,7 +20,6 @@ var _ = require('underscore'),
     thunkify = require('thunkify'),
     Emailer = require('../../lib/mailer'),
     thunkQuery = thunkify(query),
-    mc = require('../mc_helper'),
     notifications = require('../controllers/notifications');
 
 var debug = require('debug')('debug_organizations');
@@ -170,16 +169,6 @@ module.exports = {
             ));
 
             var clientThunkQuery = thunkify(new Query(req.body.realm));
-
-            if (process.env.BOOTSTRAP_MEMCACHED !== 'DISABLE') {
-                try { // reset schemas cache
-                    var schemas = yield mc.delete(req.mcClient, 'schemas');
-                } catch (e) {
-                    debug(JSON.stringify(e));
-                    throw new HttpError(500, e);
-                }
-            }
-
             req.thunkQuery = clientThunkQuery; // Do this because of bologger
 
             var org = yield clientThunkQuery(
@@ -437,7 +426,7 @@ function* checkOrgData(req) {
             throw new HttpError(400, 'name and realm fields are required');
         }
 
-        var schemas = yield adminThunkQuery(pgEscape( // better to select from db instead of memcache
+        var schemas = yield adminThunkQuery(pgEscape(
             'SELECT pg_catalog.pg_namespace.nspname ' +
             'FROM pg_catalog.pg_namespace ' +
             'INNER JOIN pg_catalog.pg_user ' +

--- a/backend/app/controllers/products.js
+++ b/backend/app/controllers/products.js
@@ -24,7 +24,6 @@ var
     SubindexWeight = require('../models/subindex_weights.js'),
     co = require('co'),
     sql = require('sql'),
-    mc = require('../mc_helper'),
     HttpError = require('../error').HttpError,
     pgEscape = require('pg-escape'),
     surveyService = require('../services/survey'),
@@ -605,14 +604,7 @@ module.exports = {
             }
 
             var ticket = crypto.randomBytes(10).toString('hex');
-
-            try {
-                var r = yield mc.set(req.mcClient, ticket, product[0].id);
-                return ticket;
-            } catch (e) {
-                throw new HttpError(500, e);
-            }
-
+            return ticket;
         }).then(function (data) {
             res.status(201).json({
                 ticket: data

--- a/backend/app/services/common.js
+++ b/backend/app/services/common.js
@@ -166,7 +166,7 @@ var getUser = function* (req, userId) {
 };
 exports.getUser = getUser;
 
-var getEssenceId = function* (req, essenceName) { // ToDo: use memcache
+var getEssenceId = function* (req, essenceName) {
     var thunkQuery = (req) ? req.thunkQuery : thunkify(new Query(config.pgConnect.adminSchema));
     var result = yield thunkQuery(Essence.select().from(Essence).where([sql.functions.UPPER(Essence.tableName).equals(essenceName.toUpperCase())]));
     if (!_.first(result)) {
@@ -779,4 +779,3 @@ var sendSystemMessageWithMessageService = function (req, to, message) {
 };
 
 exports.sendSystemMessageWithMessageService = sendSystemMessageWithMessageService;
-

--- a/backend/config.js
+++ b/backend/config.js
@@ -42,11 +42,6 @@ var environments = {
             adminSchema: 'public',
             sceletonSchema: 'sceleton'
         },
-        mc: { // memcache
-            host: process.env.MEMCACHED_HOST || 'localhost',
-            port: 11211,
-            lifetime: 300 // seconds
-        },
         max_upload_filesize: 10 * 1024 * 1024, // 10 MB
         defaultLang: 'en',
         adminRole: 'admin',
@@ -201,11 +196,6 @@ var environments = {
             port: 5432,
             adminSchema: 'public',
             sceletonSchema: 'sceleton'
-        },
-        mc: { // memcache
-            host: process.env.MEMCACHED_PORT_11211_TCP_ADDR || 'localhost',
-            port: 11211,
-            lifetime: 300 // seconds
         },
         max_upload_filesize: 10 * 1024 * 1024, // 10 MB
         defaultLang: 'en',

--- a/backend/package.json
+++ b/backend/package.json
@@ -76,7 +76,7 @@
     "sinon": "^2.3.6"
   },
   "engines": {
-    "node": "~5.0.0"
+    "node": "^6.10.0"
   },
   "scripts": {
     "start": "node --harmony app.js",

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,7 +25,6 @@
     "json2csv": "^3.11.5",
     "jsonwebtoken": "^7.4.1",
     "lodash": "^4.17.4",
-    "memcache": "0.3.0",
     "mocha": "1.20.1",
     "moment": "2.21.0",
     "multer": "0.1.3",

--- a/backend/test/discussion.integration.js
+++ b/backend/test/discussion.integration.js
@@ -177,6 +177,4 @@ describe('discussion integration', function surveyIntegration() {
     it('get discussion 0 entry scope', tests.getDiscussionEntryScopeFn(0, { canUpdate: false }));
 
     // it('list discussions', tests.listDiscussionsFn({ taskIndex: 0 }));
-
-    after(shared.unsetupFn());
 });

--- a/backend/test/group.integration.js
+++ b/backend/test/group.integration.js
@@ -83,6 +83,4 @@ describe('group integration', function uoaTypeIntegration() {
     it('list groups', tests.listGroupsFn());
 
     it('logout as admin', shared.logoutFn());
-
-    after(shared.unsetupFn());
 });

--- a/backend/test/product.integration.js
+++ b/backend/test/product.integration.js
@@ -60,6 +60,4 @@ describe('product integration', function surveyIntegration() {
     it('list products', tests.listProductsFn());
 
     it('logout as admin', shared.logoutFn());
-
-    after(shared.unsetupFn());
 });

--- a/backend/test/survey.integration.js
+++ b/backend/test/survey.integration.js
@@ -179,6 +179,4 @@ describe('survey integration', function surveyIntegration() {
     });
 
     it('logout as admin', shared.logoutFn());
-
-    after(shared.unsetupFn());
 });

--- a/backend/test/task.integration.js
+++ b/backend/test/task.integration.js
@@ -157,6 +157,4 @@ describe('task integration', function surveyIntegration() {
     // });
 
     it('logout as admin', shared.logoutFn());
-
-    after(shared.unsetupFn());
 });

--- a/backend/test/task_dev.integration.js
+++ b/backend/test/task_dev.integration.js
@@ -136,6 +136,4 @@ describe('task integration with config authentication', function surveyIntegrati
     it('reset config', function resetConfig() {
         config.devUserToken  = null;
     });
-
-    after(shared.unsetupFn());
 });

--- a/backend/test/uoa.integration.js
+++ b/backend/test/uoa.integration.js
@@ -92,6 +92,4 @@ describe('uoa integration', function uoaTypeIntegration() {
     it('list unit of analysis', tests.listUOAsFn());
 
     it('logout as admin', shared.logoutFn());
-
-    after(shared.unsetupFn());
 });

--- a/backend/test/uoaclasstype.integration.js
+++ b/backend/test/uoaclasstype.integration.js
@@ -76,6 +76,4 @@ describe('uoa class type integration', function uoaTypeIntegration() {
     it('list unit of analysis class type', tests.listUOAClassTypesFn());
 
     it('logout as admin', shared.logoutFn());
-
-    after(shared.unsetupFn());
 });

--- a/backend/test/uoatag.integration.js
+++ b/backend/test/uoatag.integration.js
@@ -80,6 +80,4 @@ describe('uoa class type integration', function uoaTypeIntegration() {
     it('list unit of analysis tag', tests.listUOATagsFn());
 
     it('logout as admin', shared.logoutFn());
-
-    after(shared.unsetupFn());
 });

--- a/backend/test/uoataglink.integration.js
+++ b/backend/test/uoataglink.integration.js
@@ -97,6 +97,4 @@ describe('uoa tag link integration', function uoaTypeIntegration() {
     it('list analysis tag links', tests.listUOATagLinksFn());
 
     it('logout as admin', shared.logoutFn());
-
-    after(shared.unsetupFn());
 });

--- a/backend/test/uoatype.integration.js
+++ b/backend/test/uoatype.integration.js
@@ -85,6 +85,4 @@ describe('uoa type integration', function uoaTypeIntegration() {
     it('list unit of analysis type', tests.listUOATypesFn());
 
     it('logout as admin', shared.logoutFn());
-
-    after(shared.unsetupFn());
 });

--- a/backend/test/user.integration.js
+++ b/backend/test/user.integration.js
@@ -96,6 +96,4 @@ describe('user integration', function userIntegration() {
     it('verify user 2', userTests.getUserFn(2));
 
     it('logout as admin', shared.logoutFn());
-
-    after(shared.unsetupFn());
 });

--- a/backend/test/util/shared-integration.js
+++ b/backend/test/util/shared-integration.js
@@ -1,13 +1,11 @@
 'use strict';
 
-const sinon = require('sinon');
+// const sinon = require('sinon');
 
 const appGenerator = require('../../app/app-generator');
 
 const config = require('../../config');
 const models = require('../../models');
-
-const memcacheMock = require('./memcache-mock')
 
 const essences = require('../fixtures/seed/essences_0');
 const languages = require('../fixtures/seed/languages_0');
@@ -134,14 +132,10 @@ class SharedIntegration {
         this.hxUser = hxUser;
     }
 
-    initialize(db, mcl) {
+    initialize(db) {
         return syncAndSeed(db)
             .then(() => {
                 const app = appGenerator.generate();
-                const mcClient = app.locals.mcClient;
-                sinon.stub(mcClient, 'set').callsFake((key, value, cb) => mcl.set(key, value, cb));
-                sinon.stub(mcClient, 'get').callsFake((key, cb) => mcl.get(key, cb));
-                sinon.stub(mcClient, 'delete').callsFake((key, cb) => mcl.delete(key, cb));
                 this.indaSuperTest.initialize(app);
             });
     }
@@ -149,16 +143,14 @@ class SharedIntegration {
 
     setupFn() {
         const that = this;
-        const mcl = new memcacheMock.Client();
         const db = models(config.pgConnect, ['sceleton', 'test']);
         return function setUp() {
-            return that.initialize(db, mcl);
+            return that.initialize(db);
         };
     }
 
     setupForSeedFn() {
         const that = this;
-        const mcl = new memcacheMock.Client();
         const db = models(config.pgConnect, ['sceleton', 'test']);
         return function setUp() {
             const query = `SELECT COUNT(*) AS count FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'Users'`;
@@ -166,7 +158,7 @@ class SharedIntegration {
                 .then((result) => {
                     const count = result[0].count;
                     if ((count === 0) || (count === '0')) {
-                        return that.initialize(db, mcl).then(() => true);
+                        return that.initialize(db).then(() => true);
                     }
                     return false;
                 });
@@ -185,16 +177,6 @@ class SharedIntegration {
         return function logout() {
             indaSuperTest.resetAuth();
         };
-    }
-
-    unsetupFn() {
-        const indaSuperTest = this.indaSuperTest;
-        return function unsetup() {
-            const mcClient = indaSuperTest.app.locals.mcClient;
-            mcClient.set.restore();
-            mcClient.get.restore();
-            mcClient.delete.restore();
-        }
     }
 
     setupDb() {

--- a/backend/test/workflow.integration.js
+++ b/backend/test/workflow.integration.js
@@ -96,6 +96,4 @@ describe('workflow integration', function surveyIntegration() {
     it('get workflow (no step information)', tests.getWorkflowFn(0));
 
     it('logout as admin', shared.logoutFn());
-
-    after(shared.unsetupFn());
 });

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
+"@types/geojson@^1.0.0":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-1.0.6.tgz#3e02972728c69248c2af08d60a48cbb8680fffdf"
+
+"@types/node@*":
+  version "10.3.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.3.5.tgz#8423cdf6e6fb83433e489900d7600d3b61c8260c"
+
 JSONStream@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.2.tgz#c102371b6ec3a7cf3b847ca00c20bb0fce4c6dea"
@@ -332,7 +340,7 @@ blob@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/blob/-/blob-0.0.4.tgz#bcf13052ca54463f30f9fc7e95b9a47630a94921"
 
-bluebird@^3.0.5, bluebird@^3.5.0:
+bluebird@^3.0.5, bluebird@^3.4.6, bluebird@^3.5.0:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
 
@@ -576,6 +584,13 @@ clone@^0.2.0:
 clone@^1.0.0, clone@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.3.tgz#298d7e2231660f40c003c2ed3140decf3f53085f"
+
+cls-bluebird@^2.0.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cls-bluebird/-/cls-bluebird-2.1.0.tgz#37ef1e080a8ffb55c2f4164f536f1919e7968aee"
+  dependencies:
+    is-bluebird "^1.0.2"
+    shimmer "^1.1.0"
 
 "co@4.0.0 ":
   version "4.0.0"
@@ -835,13 +850,13 @@ dateformat@~1.0.12:
     get-stdin "^4.0.1"
     meow "^3.3.0"
 
-debug@*, debug@^3.1.0:
+debug@*, debug@^3.0.0, debug@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
     ms "2.0.0"
 
-debug@2, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3:
+debug@2, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -939,6 +954,10 @@ delayed-stream@0.0.5:
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+
+depd@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
 
 depd@~1.0.0:
   version "1.0.1"
@@ -1039,6 +1058,10 @@ domutils@1.5:
 dotenv@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-4.0.0.tgz#864ef1379aced55ce6f95debecdce179f7a0cd1d"
+
+dottie@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dottie/-/dottie-2.0.0.tgz#da191981c8b8d713ca0115d5898cf397c2f0ddd0"
 
 duplexer2@0.0.2:
   version "0.0.2"
@@ -1798,6 +1821,10 @@ generic-pool@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/generic-pool/-/generic-pool-2.1.1.tgz#af04dc2c325cfcb975023fa52bfce9617a7435fd"
 
+generic-pool@^3.1.8:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/generic-pool/-/generic-pool-3.4.2.tgz#92ff7196520d670839a67308092a12aadf2f6a59"
+
 get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
@@ -2320,6 +2347,10 @@ indexof@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/indexof/-/indexof-0.0.1.tgz#82dc336d232b9062179d05ab3293a66059fd435d"
 
+inflection@1.12.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/inflection/-/inflection-1.12.0.tgz#a200935656d6f5f6bc4dc7502e1aecb703228416"
+
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -2418,6 +2449,10 @@ is-accessor-descriptor@^1.0.0:
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
+
+is-bluebird@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-bluebird/-/is-bluebird-1.0.2.tgz#096439060f4aa411abee19143a84d6a55346d6e2"
 
 is-buffer@^1.1.5, is-buffer@~1.1.5:
   version "1.1.6"
@@ -3049,6 +3084,10 @@ lodash@^3.5.0, lodash@^3.7.0, lodash@~3.10.0, lodash@~3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
+lodash@^4.17.1:
+  version "4.17.10"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
+
 lodash@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-1.0.2.tgz#8f57560c83b59fc270bd3d561b690043430e2551"
@@ -3289,13 +3328,23 @@ mock-require@^2.0.2:
   dependencies:
     caller-id "^0.1.0"
 
-moment@2.11.2:
-  version "2.11.2"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.11.2.tgz#87968e5f95ac038c2e42ac959c75819cd3f52901"
+moment-timezone@^0.5.4:
+  version "0.5.21"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.21.tgz#3cba247d84492174dbf71de2a9848fa13207b845"
+  dependencies:
+    moment ">= 2.9.0"
+
+moment@2.21.0:
+  version "2.21.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.21.0.tgz#2a114b51d2a6ec9e6d83cf803f838a878d8a023a"
 
 moment@2.x.x, moment@latest:
   version "2.20.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.20.1.tgz#d6eb1a46cbcc14a2b2f9434112c1ff8907f313fd"
+
+"moment@>= 2.9.0", moment@^2.13.0:
+  version "2.22.2"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
 
 ms@0.6.2:
   version "0.6.2"
@@ -4181,6 +4230,13 @@ ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
 
+retry-as-promised@^2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/retry-as-promised/-/retry-as-promised-2.3.2.tgz#cd974ee4fd9b5fe03cbf31871ee48221c07737b7"
+  dependencies:
+    bluebird "^3.4.6"
+    debug "^2.6.9"
+
 revalidator@0.1.x:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/revalidator/-/revalidator-0.1.8.tgz#fece61bfa0c1b52a206bd6b18198184bdd523a3b"
@@ -4233,7 +4289,7 @@ sax@1.2.1, sax@>=0.6.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
 
-"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0:
+"semver@2 || 3 || 4 || 5", semver@^5.0.1, semver@^5.1.0, semver@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
@@ -4255,6 +4311,28 @@ send@0.10.1:
     ms "0.6.2"
     on-finished "~2.1.1"
     range-parser "~1.0.2"
+
+sequelize@4.20.3:
+  version "4.20.3"
+  resolved "https://registry.yarnpkg.com/sequelize/-/sequelize-4.20.3.tgz#ff9f17ce395b27fecdffd349049c3bb4718ba686"
+  dependencies:
+    bluebird "^3.4.6"
+    cls-bluebird "^2.0.1"
+    debug "^3.0.0"
+    depd "^1.1.0"
+    dottie "^2.0.0"
+    generic-pool "^3.1.8"
+    inflection "1.12.0"
+    lodash "^4.17.1"
+    moment "^2.13.0"
+    moment-timezone "^0.5.4"
+    retry-as-promised "^2.3.1"
+    semver "^5.0.1"
+    terraformer-wkt-parser "^1.1.2"
+    toposort-class "^1.0.1"
+    uuid "^3.0.0"
+    validator "^9.1.0"
+    wkx "^0.4.1"
 
 sequencify@~0.0.7:
   version "0.0.7"
@@ -4310,6 +4388,10 @@ shelljs@0.3.x:
 shelljs@^0.6.0:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.6.1.tgz#ec6211bed1920442088fe0f70b2837232ed2c8a8"
+
+shimmer@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shimmer/-/shimmer-1.2.0.tgz#f966f7555789763e74d8841193685a5e78736665"
 
 sigmund@^1.0.1, sigmund@~1.0.0:
   version "1.0.1"
@@ -4765,6 +4847,19 @@ tar-stream@^1.1.2, tar-stream@latest:
     readable-stream "^2.0.0"
     xtend "^4.0.0"
 
+terraformer-wkt-parser@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/terraformer-wkt-parser/-/terraformer-wkt-parser-1.2.0.tgz#c9d6ac3dff25f4c0bd344e961f42694961834c34"
+  dependencies:
+    "@types/geojson" "^1.0.0"
+    terraformer "~1.0.5"
+
+terraformer@~1.0.5:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/terraformer/-/terraformer-1.0.9.tgz#77851fef4a49c90b345dc53cf26809fdf29dcda6"
+  optionalDependencies:
+    "@types/geojson" "^1.0.0"
+
 text-encoding@0.6.4:
   version "0.6.4"
   resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
@@ -4849,6 +4944,10 @@ topo@1.x.x:
   resolved "https://registry.yarnpkg.com/topo/-/topo-1.1.0.tgz#e9d751615d1bb87dc865db182fa1ca0a5ef536d5"
   dependencies:
     hoek "2.x.x"
+
+toposort-class@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/toposort-class/-/toposort-class-1.0.1.tgz#7ffd1f78c8be28c3ba45cd4e1a3f5ee193bd9988"
 
 tough-cookie@>=2.3.3, tough-cookie@~2.3.3:
   version "2.3.3"
@@ -5054,6 +5153,10 @@ uuid@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
 
+uuid@^3.0.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
+
 v8flags@^2.0.2:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-2.1.1.tgz#aab1a1fa30d45f88dd321148875ac02c0b55e5b4"
@@ -5070,6 +5173,10 @@ validate-npm-package-license@^3.0.1:
 validator@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/validator/-/validator-5.0.0.tgz#c0b54a5b831f8ef8f6dd6fe49a9c707600ec65ef"
+
+validator@^9.1.0:
+  version "9.4.1"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-9.4.1.tgz#abf466d398b561cd243050112c6ff1de6cc12663"
 
 vary@~1.0.0:
   version "1.0.1"
@@ -5159,6 +5266,12 @@ winston@0.8.x:
     isstream "0.1.x"
     pkginfo "0.3.x"
     stack-trace "0.0.x"
+
+wkx@^0.4.1:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/wkx/-/wkx-0.4.5.tgz#a85e15a6e69d1bfaec2f3c523be3dfa40ab861d0"
+  dependencies:
+    "@types/node" "*"
 
 wordwrap@~1.0.0:
   version "1.0.0"

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -3169,10 +3169,6 @@ media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
 
-memcache@0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/memcache/-/memcache-0.3.0.tgz#bdbb978ea4bee0fdd3166997b1883d297e0859dc"
-
 meow@^3.3.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,6 @@ services:
       INDABA_PG_HOSTNAME: ${INDABA_PG_HOSTNAME}
       INDABA_PG_TESTUSER: ${INDABA_PG_TESTUSER}
       AUTH_SALT:          ${AUTH_SALT}
-      MEMCACHED_HOST:     memcached
       JWT_SECRET:         veryverysecret
       AUTH_SERVICE_URL:   auth-service
       SURVEY_SERVICE_URL: survey-service
@@ -28,11 +27,6 @@ services:
     - POSTGRES_USER=amida
     - POSTGRES_PASSWORD=amida
     - POSTGRES_DB=indaba
-
-  memcached:
-    image: "memcached:1.5.4"
-    ports:
-    - "11211:11211"
 
   auth-db:
     image: "postgres:10.1"

--- a/kubernetes.yml
+++ b/kubernetes.yml
@@ -23,8 +23,6 @@ spec:
           value: kubernetes-indaba.host_url.us-west-2.rds.amazonaws.com
         - name: INDABA_PG_TESTUSER
           value: indaba
-        - name: MEMCACHED_HOST
-          value: amida-kubernetes.host_url.cfg.usw2.cache.amazonaws.com
         - name: INDABA_PG_DB
           value: amida_indaba
         - name: AUTH_SALT

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -9,8 +9,7 @@ cluster running on your local machine.
 You are more than welcome to set up the individual Indaba services from scratch. However, this repository provides a template for
 a functioning Indaba application. It contains the following components:
 - An empty Postgres database
-- A memcached container
-- An Indaba backend instance, networked to Postgres and memcached.
+- An Indaba backend instance, networked to Postgres.
 - An Indaba frontend instance, networked to the backend, and with a load balancer mapping from port 80 to port 8080, running HTTP.
 
 To initialize the template, simply run:


### PR DESCRIPTION
#### What does this PR do?
For INBA-887, moves the version of Node and Moment.js up to get around a security vulnerability.

For INBA-888, removes memcached. 

#### Related JIRA tickets:
INBA-887, INBA-888

#### How should this be manually tested?
Set your node to anything between 6.10.0 and 6.12.2. Do not go past version 6 just yet.  Run `yarn` install. Turn off memcached services. 

Regression test by creating projects, surveys, etc in Indaba to ensure that nothing is broken. Run tests, blow everything away and run seed.js. Check *everything*. 

@ElijahGeorge, please review the yaml files and ensure that I haven't broken anything. 
#### Background/Context

#### Screenshots (if appropriate):
