### PR TITLE
[INBA-929][INBA-853] Change that orders the tasks for a user by due date.

### DIFF
--- a/backend/app/controllers/tasks.js
+++ b/backend/app/controllers/tasks.js
@@ -182,7 +182,8 @@ module.exports = {
                 'LEFT JOIN "Projects" ' +
                 'ON "Projects".id ' +
                 '= "Products".id ' +
-                'WHERE ' + req.user.id + ' = ANY("Tasks"."userIds")' +
+                'WHERE ' + req.user.id + ' = ANY("Tasks"."userIds") ' +
+                'AND "Tasks"."startDate" <= now() ' +
                 'AND "Tasks"."isDeleted" is NULL ' +
                 'ORDER BY "Tasks"."endDate" ASC ' +
                 ') '

--- a/backend/app/controllers/tasks.js
+++ b/backend/app/controllers/tasks.js
@@ -184,6 +184,7 @@ module.exports = {
                 '= "Products".id ' +
                 'WHERE ' + req.user.id + ' = ANY("Tasks"."userIds")' +
                 'AND "Tasks"."isDeleted" is NULL ' +
+                'ORDER BY "Tasks"."endDate" ASC ' +
                 ') '
             );
             tasks = yield * common.getDiscussedTasks(req, tasks, req.user.id);


### PR DESCRIPTION
#### What does this PR do?
A user's assigned tasks will now return based on the task's due date, from earliest to latest.

Also allows the future tasks not to be given to the user on the tasks page.

#### Related JIRA tickets:
INBA-929.
INBA-853.

#### How should this be manually tested?
Assign a user several tasks. They can be different projects or the same one, preferably with the individual tasks have different end dates. Log in as that user and confirm that the due dates are ordered. (See screenshot below.)

Also, give a user a task in the future. It should not appear in the list. Change the start date for that particular task in the back end (under the `Tasks` table) and it should then appear when the user refreshs.

#### Background/Context
Tasks are given an initial end date based on the stage's end date. The task's end date can be changed if the admin goes into the tasks and chooses a new date from the "Task End Date" up top. 

#### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4026454/48506670-f0fffc00-e817-11e8-88f4-a494fbca02e2.png)
