### PR TITLE
INBA-911 / Orders by last updated on "listAll" of the projects

### DIFF
--- a/backend/app/controllers/projects.js
+++ b/backend/app/controllers/projects.js
@@ -92,7 +92,9 @@ module.exports = {
         var projectList = [];
 
         co(function* () {
-            var projects = yield thunkQuery(Project.select().from(Project), req.query);
+            var projects = yield thunkQuery(
+                'SELECT * FROM "Projects" ORDER BY "Projects"."lastUpdated" DESC'
+            );
 
             if (!_.first(projects)) {
                 return projectList;


### PR DESCRIPTION
#### What does this PR do?
Changes the project listing to return the projects by the latest updated first, down.

#### Related JIRA tickets:
INBA-911

#### How should this be manually tested?
Log in as an admin, check that the projects are ordered from most recently updated to the longest ago.

#### Background/Context
We don't really use the query aspect of it. But if you can think of any circumstances in which I may be wrong, please check.

#### Screenshots (if appropriate):
