### PR TITLE
Feature/inba 911 jf order projects by last updated

### DIFF
--- a/backend/app/controllers/projects.js
+++ b/backend/app/controllers/projects.js
@@ -219,6 +219,7 @@ module.exports = {
                         )
                         .where(Product.projectId.equals(project.id).and(WorkflowSteps.isDeleted.isNull()))
                         .group(WorkflowSteps.id)
+                        .order(WorkflowSteps.position)
                 );
 
                 // Add unique workflowID's to a new list

--- a/backend/app/controllers/projects.js
+++ b/backend/app/controllers/projects.js
@@ -134,6 +134,7 @@ module.exports = {
                                 .from(WorkflowSteps)
                                 .where(WorkflowSteps.workflowId.equals(workflowId))
                                 .and(WorkflowSteps.isDeleted.isNull())
+                                .order(WorkflowSteps.position)
                         );
                         for (var index = 0; index < stages.length; index++) {
                             stages[index].userGroups = [];

--- a/backend/app/controllers/projects.js
+++ b/backend/app/controllers/projects.js
@@ -92,7 +92,9 @@ module.exports = {
         var projectList = [];
 
         co(function* () {
-            var projects = yield thunkQuery(Project.select().from(Project), req.query);
+            var projects = yield thunkQuery(
+                'SELECT * FROM "Projects" ORDER BY "Projects"."lastUpdated" DESC'
+            );
 
             if (!_.first(projects)) {
                 return projectList;


### PR DESCRIPTION
Postgres decided out of the blue to shake up how it returns ordering for Stages inside a project. Normally it follows per the creation date of rows but for some reason decided not to today. We're taking steps to reduce the risk on our system.


#### What does this PR do?

#### Related JIRA tickets:

#### Did the user.integration, discussion.integration and task.integration tests pass? Test can be run with:
#### node_modules/.bin/mocha test/user.integration.js test/discussion.integration.js test/task.integration.js --bail -t 10000

#### How should this be manually tested?

Create or use an existing project that has several stages, preferably up to 5 or 6. (You are capped at 4 when using the Project Wizard, but can go beyond this limit on the Project Management page). Confirm that they appear in order. Then go into your backend and try switching the order at the `WorkflowSteps` table. See the screenshot for how. You may want to put your order back when you are finished.

Also, please check that the `Projects` page for admin users lists and confirm that it is now ordered from latest to last updated. 

#### Background/Context

#### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4026454/50020858-537a2280-ffa5-11e8-9f97-f9afd2c11142.png)

